### PR TITLE
0.5.0-part-1: Property access methods

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -299,11 +299,63 @@ class DataTransferObject
     }
 
     /**
+     * @deprecated Use the more explicit `getDefinedProperties` or `getPropertiesWithDefaults`
+     *
      * @return array
      */
     public function getProperties(): array
     {
+        return $this->getDefinedProperties();
+    }
+
+    /**
+     * @return array
+     */
+    public function getDefinedProperties(): array
+    {
         return $this->properties;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPropertiesWithDefaults(): array
+    {
+        // Set missing properties to defaults
+        $defaults = array_reduce(
+            array_diff_key($this->propertyTypes, $this->getDefinedPropertyNames()),
+            function (array $carry, Property $type): array {
+                foreach ($type->mapProcessedDefault($this->flags) as $name => $default) {
+                    $carry[$name] = $default;
+                }
+                return $carry;
+            },
+            []
+        );
+
+        // Safe to merge because only missing keys were used to load defaults
+        return array_merge($defaults, $this->properties);
+    }
+
+    /**
+     * @return array
+     */
+    public function getUndefinedPropertyNames(): array
+    {
+        return array_values(
+            array_diff(
+                array_keys($this->propertyTypes),
+                $this->getDefinedPropertyNames()
+            )
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function getDefinedPropertyNames(): array
+    {
+        return array_keys($this->properties);
     }
 
     /**

--- a/tests/Unit/PropertyAccessTest.php
+++ b/tests/Unit/PropertyAccessTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Rexlabs\DataTransferObject\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Rexlabs\DataTransferObject\DataTransferObject;
+use Rexlabs\DataTransferObject\Factory;
+use Rexlabs\DataTransferObject\Property;
+
+use const Rexlabs\DataTransferObject\PARTIAL;
+
+class PropertyAccessTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        // Clear cached static data
+        // Also I'm sorry for caching static data
+        DataTransferObject::setFactory(null);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function can_get_only_defined_properties_from_partial(): void
+    {
+        $values = [
+            'blim' => 'test',
+            'blam' => true,
+        ];
+
+        $dto = new DataTransferObject(
+            [
+                'blim' => $this->createMock(Property::class),
+                'blam' => $this->createMock(Property::class),
+                'flim' => $this->createMock(Property::class),
+                'flam' => $this->createMock(Property::class),
+            ],
+            $values,
+            PARTIAL
+        );
+
+        self::assertEquals($values, $dto->getDefinedProperties());
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function can_get_defined_properties_with_defaults(): void
+    {
+        $factory = new Factory([]);
+        $dto = new DataTransferObject(
+            [
+                'blim' => $this->createMock(Property::class),
+                'blam' => $this->createMock(Property::class),
+                'flim' => new Property($factory, 'flim', ['array'], [], true, []),
+                'flam' => new Property($factory, 'flam', ['array', 'null'], [], true, null),
+            ],
+            [
+                'blim' => 'test',
+                'blam' => true
+            ],
+            PARTIAL
+        );
+
+        $expected = [
+            'blim' => 'test',
+            'blam' => true,
+            'flim' => [],
+            'flam' => null,
+        ];
+
+        self::assertEquals($expected, $dto->getPropertiesWithDefaults());
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function can_get_undefined_property_names(): void
+    {
+        $factory = new Factory([]);
+        $dto = new DataTransferObject(
+            [
+                'blim' => $this->createMock(Property::class),
+                'blam' => $this->createMock(Property::class),
+                'flim' => new Property($factory, 'flim', ['array'], [], true, []),
+                'flam' => new Property($factory, 'flam', ['array'], [], true, null),
+            ],
+            [
+                'blim' => 'test',
+                'blam' => true
+            ],
+            PARTIAL
+        );
+
+        $expected = [
+            'flim',
+            'flam',
+        ];
+
+        self::assertEquals($expected, $dto->getUndefinedPropertyNames());
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function can_get_defined_property_names(): void
+    {
+        $factory = new Factory([]);
+        $dto = new DataTransferObject(
+            [
+                'blim' => $this->createMock(Property::class),
+                'blam' => $this->createMock(Property::class),
+                'flim' => new Property($factory, 'flim', ['array'], [], true, []),
+                'flam' => new Property($factory, 'flam', ['array'], [], true, null),
+            ],
+            [
+                'blim' => 'test',
+                'blam' => true
+            ],
+            PARTIAL
+        );
+
+        $expected = [
+            'blim',
+            'blam',
+        ];
+
+        self::assertEquals($expected, $dto->getDefinedPropertyNames());
+    }
+}


### PR DESCRIPTION
### Issue

> Naming of “getProperties” - i feel its not clear what this method does from its name. Something like getDefinedProperties, getProvidedProperties, getInitialisedProeprties or just some really really clear docs in the docblock for that method.

### Solution

Add:

- deprecate getProperties, delgate to getDefinedProperties
- getDefinedProperties
- getPropertiesWithDefaults
- getUndefinedPropertyKeys
- getDefinedPropertyKeys