### PR TITLE
0.5.0-part-2 make helper methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "ext-json": "*"
   },
   "require-dev": {
+    "fzaninotto/faker": "^1.9",
     "phpunit/phpunit": ">=8.0",
     "squizlabs/php_codesniffer": "^3.0"
   },

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -66,28 +66,28 @@ class DataTransferObject
 
     /**
      * @param array $override
-     * @param int $flags
+     * @param null|int $flags Use current instance flags on null, else use provided flags
      * @return static
      */
-    public function remake(array $override, int $flags = NONE): self
+    public function remake(array $override, $flags = null): self
     {
         return self::make(
             array_merge($this->getDefinedProperties(), $override),
-            $flags
+            $flags ?? $this->flags
         );
     }
 
     /**
      * @param array $onlyPropertyNames
      * @param array $override
-     * @param int $flags
+     * @param null|int $flags Use current instance flags on null, else use provided flags
      *
      * @return static
      */
     public function remakeOnly(
         array $onlyPropertyNames,
         array $override,
-        int $flags = NONE
+        $flags = null
     ): self {
         // TODO assert valid property names for $onlyPropertyNames
         $properties = array_intersect_key(
@@ -95,13 +95,16 @@ class DataTransferObject
             array_flip($onlyPropertyNames)
         );
 
-        return self::make(array_merge($properties, $override), $flags);
+        return self::make(
+            array_merge($properties, $override),
+            $flags ?? $this->flags
+        );
     }
 
     /**
      * @param array $exceptPropertyNames
      * @param array $override
-     * @param int $flags
+     * @param null|int $flags Use current instance flags on null, else use provided flags
      *
      * @return static
      */

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -65,6 +65,61 @@ class DataTransferObject
     }
 
     /**
+     * @param array $override
+     * @param int $flags
+     * @return static
+     */
+    public function remake(array $override, int $flags = NONE): self
+    {
+        return self::make(
+            array_merge($this->getDefinedProperties(), $override),
+            $flags
+        );
+    }
+
+    /**
+     * @param array $onlyPropertyNames
+     * @param array $override
+     * @param int $flags
+     *
+     * @return static
+     */
+    public function remakeOnly(
+        array $onlyPropertyNames,
+        array $override,
+        int $flags = NONE
+    ): self {
+        // TODO assert valid property names for $onlyPropertyNames
+        $properties = array_intersect_key(
+            $this->getDefinedProperties(),
+            array_flip($onlyPropertyNames)
+        );
+
+        return self::make(array_merge($properties, $override), $flags);
+    }
+
+    /**
+     * @param array $exceptPropertyNames
+     * @param array $override
+     * @param int $flags
+     *
+     * @return static
+     */
+    public function remakeExcept(
+        array $exceptPropertyNames,
+        array $override,
+        int $flags = NONE
+    ): self {
+        // TODO assert valid property names for $exceptPropertyNames
+        $properties = array_diff_key(
+            $this->getDefinedProperties(),
+            array_flip($exceptPropertyNames)
+        );
+
+        return self::make(array_merge($properties, $override), $flags);
+    }
+
+    /**
      * @param array $propertyNames
      * @param array $parameters
      * @param int $flags

--- a/tests/Unit/RemakeTest.php
+++ b/tests/Unit/RemakeTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Rexlabs\DataTransferObject\Tests\Unit;
+
+use Faker\Factory;
+use PHPUnit\Framework\TestCase;
+use Rexlabs\DataTransferObject\Tests\Feature\Examples\TestingDto;
+
+use const Rexlabs\DataTransferObject\PARTIAL;
+
+class RemakeTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function can_remake_with_overrides(): void
+    {
+        $faker = Factory::create();
+        $dto = TestingDto::make([
+            'id' => $faker->uuid,
+            'first_name' => $faker->firstName,
+            'last_name' => $faker->lastName,
+        ]);
+
+        $remade = $dto->remake([
+            'last_name' => 'Dirt',
+        ]);
+
+        self::assertEquals($dto->id, $remade->id);
+        self::assertEquals($dto->first_name, $remade->first_name);
+        self::assertEquals('Dirt', $remade->last_name);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function can_remake_only_props(): void
+    {
+        $faker = Factory::create();
+        $dto = TestingDto::make([
+            'id' => $faker->uuid,
+            'first_name' => $faker->firstName,
+            'last_name' => $faker->lastName,
+        ]);
+
+        $remade = $dto->remakeOnly(['id', 'last_name'], [], PARTIAL);
+
+        self::assertEquals($dto->id, $remade->id);
+        self::assertFalse($remade->isDefined('first_name'));
+        self::assertEquals($dto->last_name, $remade->last_name);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function can_remake_except_props(): void
+    {
+        $faker = Factory::create();
+        $dto = TestingDto::make([
+            'id' => $faker->uuid,
+            'first_name' => $faker->firstName,
+            'last_name' => $faker->lastName,
+        ]);
+
+        $remade = $dto->remakeExcept(['last_name'], [], PARTIAL);
+
+        self::assertEquals($dto->id, $remade->id);
+        self::assertEquals($dto->first_name, $remade->first_name);
+        self::assertFalse($remade->isDefined('last_name'));
+    }
+}


### PR DESCRIPTION
### Issue 

> I’m finding myself quite frequently needing to modify them but not wanting them to be mutable - I really want a remake($override, $flags) method accessible on the object.

Scenarios:

- New model with few changes
- New model with few changes AND without some props

### Solution

- Add `remake(array $override, $flags = default to object remaking from)`
- Add `remakeOnly(array $onlyPropNames, array $override, $flags = default to object remaking from)`
- Add `remakeExcept(array $exceptPropNames, array $override, $flags, = default to object remaking from)`

```php
# This
$remake = $made->remake(['with' => 'this'], ['not', 'these'], NONE);

# Instead of this
$remake = Dto::make(array_merge(
  $made->getDefinedProperties()
  ['whith' => 'this'],
), NONE);

# Or worse, this
$remake = Dto::make(array_merge(
  Arr:except($made->getDefinedProperties(), ['not', 'these']),
  ['whith' => 'this'],
), NONE);
```