### PR TITLE
0.5.0-part-4: assert defined

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -346,9 +346,7 @@ class DataTransferObject
      */
     private function assertKnownPropertyNames($propertyNames): void
     {
-        $unknown = array_filter((array) $propertyNames, function (string $propertyName) {
-            return !array_key_exists($propertyName, $this->propertyTypes);
-        });
+        $unknown = array_diff((array)$propertyNames, array_keys($this->propertyTypes));
 
         if (!empty($unknown)) {
             throw new UnknownPropertiesError($unknown);

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rexlabs\DataTransferObject;
 
+use Rexlabs\DataTransferObject\Exceptions\UninitialisedPropertiesError;
 use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesError;
 
 class DataTransferObject
@@ -89,7 +90,8 @@ class DataTransferObject
         array $override,
         int $flags = NONE
     ): self {
-        // TODO assert valid property names for $onlyPropertyNames
+        $this->assertKnownPropertyNames($onlyPropertyNames);
+
         $properties = array_intersect_key(
             $this->getDefinedProperties(),
             array_flip($onlyPropertyNames)
@@ -110,7 +112,8 @@ class DataTransferObject
         array $override,
         int $flags = NONE
     ): self {
-        // TODO assert valid property names for $exceptPropertyNames
+        $this->assertKnownPropertyNames($exceptPropertyNames);
+
         $properties = array_diff_key(
             $this->getDefinedProperties(),
             array_flip($exceptPropertyNames)
@@ -316,6 +319,40 @@ class DataTransferObject
     public function getDefinedPropertyNames(): array
     {
         return array_keys($this->properties);
+    }
+
+    /**
+     * @param string|array $propertyNames
+     *
+     * @return void
+     */
+    public function assertDefined($propertyNames): void
+    {
+        $this->assertKnownPropertyNames($propertyNames);
+
+        $undefined = array_filter((array) $propertyNames, function (string $propertyName) {
+            return !$this->isDefined($propertyName);
+        });
+
+        if (!empty($undefined)) {
+            throw new UninitialisedPropertiesError($undefined, static::class);
+        }
+    }
+
+    /**
+     * @param string|array $propertyNames
+     *
+     * @return void
+     */
+    private function assertKnownPropertyNames($propertyNames): void
+    {
+        $unknown = array_filter((array) $propertyNames, function (string $propertyName) {
+            return !array_key_exists($propertyName, $this->propertyTypes);
+        });
+
+        if (!empty($unknown)) {
+            throw new UnknownPropertiesError($unknown);
+        }
     }
 
     /**

--- a/tests/Unit/AssertionTest.php
+++ b/tests/Unit/AssertionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Rexlabs\DataTransferObject\Tests\Unit;
+
+use Faker\Factory;
+use PHPUnit\Framework\TestCase;
+use Rexlabs\DataTransferObject\Exceptions\UninitialisedPropertiesError;
+use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesError;
+use Rexlabs\DataTransferObject\Tests\Feature\Examples\TestingDto;
+
+use const Rexlabs\DataTransferObject\PARTIAL;
+
+class AssertionTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function defined_properties_passed_assertion(): void
+    {
+        $faker = Factory::create();
+        $dto = TestingDto::make([
+            'id' => $faker->uuid,
+            'last_name' => $faker->lastName,
+        ], PARTIAL);
+
+        $dto->assertDefined(['id', 'last_name']);
+
+        // No exception was thrown
+        self::assertTrue(true);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function can_test_single_string_prop(): void
+    {
+        $faker = Factory::create();
+        $dto = TestingDto::make([
+            'id' => $faker->uuid,
+            'last_name' => $faker->lastName,
+        ], PARTIAL);
+
+        $dto->assertDefined('id');
+
+        // No exception was thrown
+        self::assertTrue(true);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function undefined_properties_fail_assertion(): void
+    {
+        $faker = Factory::create();
+        $dto = TestingDto::make([
+            'id' => $faker->uuid,
+            'first_name' => $faker->firstName,
+        ], PARTIAL);
+
+        $this->expectException(UninitialisedPropertiesError::class);
+
+        $dto->assertDefined(['last_name']);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function unknown_properties_fail_before_assertion(): void
+    {
+        $faker = Factory::create();
+        $dto = TestingDto::make([
+            'id' => $faker->uuid,
+            'first_name' => $faker->firstName,
+        ], PARTIAL);
+
+        $this->expectException(UnknownPropertiesError::class);
+
+        $dto->assertDefined(['flim']);
+    }
+}

--- a/tests/Unit/RemakeTest.php
+++ b/tests/Unit/RemakeTest.php
@@ -4,6 +4,7 @@ namespace Rexlabs\DataTransferObject\Tests\Unit;
 
 use Faker\Factory;
 use PHPUnit\Framework\TestCase;
+use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesError;
 use Rexlabs\DataTransferObject\Tests\Feature\Examples\TestingDto;
 
 use const Rexlabs\DataTransferObject\PARTIAL;
@@ -73,5 +74,43 @@ class RemakeTest extends TestCase
         self::assertEquals($dto->id, $remade->id);
         self::assertEquals($dto->first_name, $remade->first_name);
         self::assertFalse($remade->isDefined('last_name'));
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function remake_rejects_unknown_only_names(): void
+    {
+        $faker = Factory::create();
+        $dto = TestingDto::make([
+            'id' => $faker->uuid,
+            'first_name' => $faker->firstName,
+            'last_name' => $faker->lastName,
+        ]);
+
+        $this->expectException(UnknownPropertiesError::class);
+
+        $dto->remakeExcept(['flim'], [], PARTIAL);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function remake_rejects_unknown_except_names(): void
+    {
+        $faker = Factory::create();
+        $dto = TestingDto::make([
+            'id' => $faker->uuid,
+            'first_name' => $faker->firstName,
+            'last_name' => $faker->lastName,
+        ]);
+
+        $this->expectException(UnknownPropertiesError::class);
+
+        $dto->remakeExcept(['flam'], [], PARTIAL);
     }
 }


### PR DESCRIPTION
https://github.com/rexlabsio/data-transfer-object/issues/4

Add assert defined method. 

```php
/**
 * @throws SomethingExtendingInvalidArgument
 */
function assertDefined(array|string $propertyNames): void
```