### PR TITLE
0.5.0-part-5: track unknown properties

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -26,14 +26,22 @@ class DataTransferObject
     protected $flags;
 
     /**
+     * Additional unknown properties provided at make time
+     * Usually discarded unless made with the `TRACK_UNKNOWN_PROPERTIES` flag
+     *
+     * @var array
+     */
+    private $unknownProperties;
+
+    /**
      * No validation or checking is done in constructor
      * Use `MyTransferObject::make($data)` instead
-     *
-     * @internal Use `MyTransferObject::make`
      *
      * @param array $propertyTypes keyed by property name
      * @param array $properties keyed by property name
      * @param int $flags
+     *
+     * @internal Use `MyTransferObject::make`
      */
     public function __construct(
         array $propertyTypes,
@@ -43,6 +51,7 @@ class DataTransferObject
         $this->propertyTypes = $propertyTypes;
         $this->properties = $properties;
         $this->flags = $flags;
+        $this->unknownProperties = [];
     }
 
     /**
@@ -322,6 +331,14 @@ class DataTransferObject
     }
 
     /**
+     * @return array
+     */
+    public function getUnknownPropertyNames(): array
+    {
+        return array_keys($this->unknownProperties);
+    }
+
+    /**
      * @param string|array $propertyNames
      *
      * @return void
@@ -389,5 +406,21 @@ class DataTransferObject
         }
 
         return $data;
+    }
+
+    /**
+     * @return array
+     */
+    public function getUnknownProperties(): array
+    {
+        return $this->unknownProperties;
+    }
+
+    /**
+     * @param array $unknownProperties
+     */
+    public function setUnknownProperties(array $unknownProperties): void
+    {
+        $this->unknownProperties = $unknownProperties;
     }
 }

--- a/src/Flags.php
+++ b/src/Flags.php
@@ -6,25 +6,32 @@ namespace Rexlabs\DataTransferObject;
 
 const NONE                         = 0;
 
+// Discard unknown properties
 const IGNORE_UNKNOWN_PROPERTIES    = 1;
 
+// Store unknown properties separately for debugging
+const TRACK_UNKNOWN_PROPERTIES     = 1 << 1;
+
 // Allow edits, objects are immutable by default
-const MUTABLE                      = 1 << 1;
+const MUTABLE                      = 1 << 2;
 
 // Default properties with an array type to an empty array
-const ARRAY_DEFAULT_TO_EMPTY_ARRAY = 1 << 2;
+const ARRAY_DEFAULT_TO_EMPTY_ARRAY = 1 << 3;
 
 // Default nullable properties to null
-const NULLABLE_DEFAULT_TO_NULL     = 1 << 3;
+const NULLABLE_DEFAULT_TO_NULL     = 1 << 4;
 
 // Default properties with a boolean type to false
-const BOOL_DEFAULT_TO_FALSE        = 1 << 4;
+const BOOL_DEFAULT_TO_FALSE        = 1 << 5;
 
 // Ignore requirements and defaults only filling what is provided
-const PARTIAL                      = 1 << 5;
+const PARTIAL                      = 1 << 6;
 
 // Override phpdoc types; make all properties nullable
-const NULLABLE                     = 1 << 6;
+const NULLABLE                     = 1 << 7;
 
 // Override phpdoc types; make properties not nullable
-const NOT_NULLABLE                 = 1 << 7;
+const NOT_NULLABLE                 = 1 << 8;
+
+// Define missing props using default values
+const DEFAULTS                     = 1 << 9;

--- a/tests/Unit/BitwiseFlagsTest.php
+++ b/tests/Unit/BitwiseFlagsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Rexlabs\DataTransferObject\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class BitwiseFlagsTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    private function getAllFlags(): array
+    {
+        $userConstants = get_defined_constants(true)['user'];
+
+        return array_reduce(
+            array_keys($userConstants),
+            function (array $carry, $name) use ($userConstants): array {
+                if (strpos($name, 'Rexlabs\DataTransferObject') !== false) {
+                    $carry[] = $userConstants[$name];
+                }
+
+                return $carry;
+            },
+            []
+        );
+    }
+
+    /**
+     * Safeguards against accidentally breaking the bitwise flag values.
+     * As long as each value is unique the flags will work.
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function flags_are_unique(): void
+    {
+        $flags = $this->getAllFlags();
+
+        // Compare each flag to every other flag
+        foreach ($flags as $i => $flag) {
+            foreach ($flags as $j => $otherFlag) {
+                // No need to compare to self
+                if ($j === $i) {
+                    continue;
+                }
+
+                self::assertNotEquals($flag, $otherFlag, 'Bitwise flags must be unique');
+            }
+        }
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function flags_are_integers(): void
+    {
+        foreach ($this->getAllFlags() as $flag) {
+            self::assertIsInt($flag, 'Bitwise flags must be ints');
+        }
+    }
+}

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -13,15 +13,14 @@ use Rexlabs\DataTransferObject\Exceptions\ImmutableError;
 use Rexlabs\DataTransferObject\Exceptions\InvalidFlagsException;
 use Rexlabs\DataTransferObject\Exceptions\InvalidTypeError;
 use Rexlabs\DataTransferObject\Exceptions\UninitialisedPropertiesError;
-use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesError;
-use Rexlabs\DataTransferObject\Property;
 use Rexlabs\DataTransferObject\Factory;
+
+use Rexlabs\DataTransferObject\Property;
 
 use function spl_object_id;
 
 use const Rexlabs\DataTransferObject\ARRAY_DEFAULT_TO_EMPTY_ARRAY;
 use const Rexlabs\DataTransferObject\BOOL_DEFAULT_TO_FALSE;
-use const Rexlabs\DataTransferObject\IGNORE_UNKNOWN_PROPERTIES;
 use const Rexlabs\DataTransferObject\MUTABLE;
 use const Rexlabs\DataTransferObject\NONE;
 use const Rexlabs\DataTransferObject\NOT_NULLABLE;
@@ -304,38 +303,6 @@ class FactoryTest extends TestCase
             [],
             NONE
         );
-    }
-
-    /**
-     * @test
-     * @return void
-     */
-    public function additional_properties_throw_error(): void
-    {
-        $this->expectException(UnknownPropertiesError::class);
-
-        $this->factory->makeWithProperties(
-            [],
-            DataTransferObject::class,
-            ['blim' => 'blam'],
-            NONE
-        );
-    }
-
-    /**
-     * @test
-     * @return void
-     */
-    public function additional_properties_ignored_with_flags(): void
-    {
-        $object = $this->factory->makeWithProperties(
-            [],
-            DataTransferObject::class,
-            ['blim' => 'blam'],
-            IGNORE_UNKNOWN_PROPERTIES
-        );
-
-        self::assertEquals([], $object->toArray());
     }
 
     /**

--- a/tests/Unit/UnknownPropertiesTest.php
+++ b/tests/Unit/UnknownPropertiesTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Rexlabs\DataTransferObject\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Rexlabs\DataTransferObject\DataTransferObject;
+use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesError;
+use Rexlabs\DataTransferObject\Factory;
+
+use const Rexlabs\DataTransferObject\IGNORE_UNKNOWN_PROPERTIES;
+use const Rexlabs\DataTransferObject\NONE;
+use const Rexlabs\DataTransferObject\TRACK_UNKNOWN_PROPERTIES;
+
+class UnknownPropertiesTest extends TestCase
+{
+    /** @var Factory */
+    private $factory;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Factory([]);
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        // Clear cached static data
+        // Also I'm sorry for caching static data
+        DataTransferObject::setFactory(null);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function additional_properties_throw_error(): void
+    {
+        $this->expectException(UnknownPropertiesError::class);
+
+        $this->factory->makeWithProperties(
+            [],
+            DataTransferObject::class,
+            ['blim' => 'blam'],
+            NONE
+        );
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function additional_properties_ignored_with_ignore_flags(): void
+    {
+        $object = $this->factory->makeWithProperties(
+            [],
+            DataTransferObject::class,
+            ['blim' => 'blam'],
+            IGNORE_UNKNOWN_PROPERTIES
+        );
+
+        self::assertEquals([], $object->toArray());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function additional_properties_ignored_with_track_flag(): void
+    {
+        $object = $this->factory->makeWithProperties(
+            [],
+            DataTransferObject::class,
+            ['blim' => 'blam'],
+            TRACK_UNKNOWN_PROPERTIES
+        );
+
+        self::assertEquals([], $object->toArray());
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function cannot_query_unknown_properties_with_ignore_flag(): void
+    {
+        $unknownProperties = ['blim' => 'blam'];
+        $object = $this->factory->makeWithProperties(
+            [],
+            DataTransferObject::class,
+            $unknownProperties,
+            IGNORE_UNKNOWN_PROPERTIES
+        );
+
+        self::assertEquals([], $object->toArray());
+        self::assertEmpty($object->getUnknownProperties());
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function can_query_unknown_properties_with_track_flag(): void
+    {
+        $unknownProperties = ['blim' => 'blam'];
+        $object = $this->factory->makeWithProperties(
+            [],
+            DataTransferObject::class,
+            $unknownProperties,
+            TRACK_UNKNOWN_PROPERTIES
+        );
+
+        self::assertEquals([], $object->toArray());
+        self::assertEquals($unknownProperties, $object->getUnknownProperties());
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function can_query_unknown_property_names_with_track_flag(): void
+    {
+        $object = $this->factory->makeWithProperties(
+            [],
+            DataTransferObject::class,
+            ['blim' => 'blam'],
+            TRACK_UNKNOWN_PROPERTIES
+        );
+
+        self::assertEquals([], $object->toArray());
+        self::assertEquals(['blim'], $object->getUnknownPropertyNames());
+    }
+}


### PR DESCRIPTION
`IGNORE_UNKNOWN_PROPERTIES` discards the unused data but it would be useful to know which properties were ignored.

Add flag `TRACK_UNKNOWN_PROPERTIES` to store them in a different array and allow users to retrieve them for logging / debuggin.