### PR TITLE
1.0.0-rc1-part-2: Default flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,13 @@ Default DTO behaviour:
 This behaviour is usually what you want but there are other contexts where more flexability is required.
 
 ##### Accepting data from a web request?
-Pass the IGNORE_UNKNOWN_PROPERTIES flag on make so extra props are just discarded.
+Pass the `IGNORE_UNKNOWN_PROPERTIES` flag on make so extra props are just discarded.
 
 ##### Accepting PATCH data?
-Pass the PARTIAL flag to allow missing properties.
+Pass the `PARTIAL` flag to allow missing properties.
 
 ##### Mutating data?
-Pass the MUTABLE flag.
-
-##### Doing something advanced?
-Use the typescript inspired utility type functions like makePick makeExtract
+Pass the `MUTABLE` flag.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This behaviour is usually what you want but there are other contexts where more 
 
 ##### Accepting data from a web request?
 Pass the `IGNORE_UNKNOWN_PROPERTIES` flag on make so extra props are just discarded.
+Or pass the `TRACK_UNKNOWN_PROPERTIES` flag to store them seperately on the DTO so you know which properties were ignored.
 
 ##### Accepting PATCH data?
 Pass the `PARTIAL` flag to allow missing properties.

--- a/docs/advanced_dto_usage.md
+++ b/docs/advanced_dto_usage.md
@@ -6,7 +6,7 @@ For php this allows several variations of a defined type from a single class def
 ## Flags
 
 Flags can be passed to `::make` to allow alternate behaviour for instances.
-Flags are autoloaded by composer and should be imported with `use const`.
+Composer will autoload the namespaced flag constants. Import them with `use const`.
 
 ```php
 use const Rexlabs\DataTransferObject\MUTABLE;
@@ -15,7 +15,7 @@ use const Rexlabs\DataTransferObject\PARTIAL;
 $object = MyDto::make($data, MUTABLE | PARTIAL);
 ```
 
-Default flags for a class can be set by overriding the protected `defaultFlags` property.
+Base flags for a class can be set by overriding the protected `baseFlags` property. DTOs will merge the base flags with those passed to `make`.
 
 ```php
 use Rexlabs\DataTransferObject\DataTransferObject;

--- a/src/ClassData.php
+++ b/src/ClassData.php
@@ -23,27 +23,28 @@ class ClassData
     public $defaults;
 
     /** @var int */
-    public $defaultFlags;
+    public $baseFlags;
 
     /**
      * ClassData constructor.
+     *
      * @param string $namespace
      * @param string $contents
      * @param string $docComment
      * @param array $defaults
-     * @param int $defaultFlags
+     * @param int $baseFlags
      */
     public function __construct(
         string $namespace,
         string $contents,
         string $docComment,
         array $defaults,
-        int $defaultFlags
+        int $baseFlags
     ) {
         $this->namespace = $namespace;
         $this->contents = $contents;
         $this->docComment = $docComment;
         $this->defaults = $defaults;
-        $this->defaultFlags = $defaultFlags;
+        $this->baseFlags = $baseFlags;
     }
 }

--- a/src/DTOMetadata.php
+++ b/src/DTOMetadata.php
@@ -17,19 +17,19 @@ class DTOMetadata
     public $propertyTypes;
 
     /** @var int */
-    public $defaultFlags;
+    public $baseFlags;
 
     /**
      * DTOMetadata constructor.
      *
      * @param string $class
      * @param array $propertyTypes
-     * @param int $defaultFlags
+     * @param int $baseFlags
      */
-    public function __construct(string $class, array $propertyTypes, int $defaultFlags)
+    public function __construct(string $class, array $propertyTypes, int $baseFlags)
     {
         $this->class = $class;
         $this->propertyTypes = $propertyTypes;
-        $this->defaultFlags = $defaultFlags;
+        $this->baseFlags = $baseFlags;
     }
 }

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -12,9 +12,8 @@ class DataTransferObject
     /** @var null|FactoryContract */
     protected static $factory;
 
-    /** @var int Override to set default behaviour flags */
-    protected $defaultFlags = NULLABLE_DEFAULT_TO_NULL
-       | ARRAY_DEFAULT_TO_EMPTY_ARRAY;
+    /** @var int Base flags merge with flag parameters passed to `make` */
+    protected $baseFlags = NONE;
 
     /** @var Property[] Keyed by property name */
     protected $propertyTypes;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -87,7 +87,7 @@ REGEXP;
             $meta->propertyTypes,
             $meta->class,
             $parameters,
-            $meta->defaultFlags | $flags
+            $meta->baseFlags | $flags
         );
     }
 
@@ -109,7 +109,7 @@ REGEXP;
             return new DTOMetadata(
                 $class,
                 $this->mapClassToPropertyTypes($classData, $useStatements),
-                $classData->defaultFlags
+                $classData->baseFlags
             );
         });
     }
@@ -227,7 +227,7 @@ REGEXP;
             throw new LogicException($e->getMessage(), $e->getCode(), $e);
         }
         $refGetDefaults->setAccessible(true);
-        $defaultFlags = $refClass->getDefaultProperties()['defaultFlags'] ?? NONE;
+        $baseFlags = $refClass->getDefaultProperties()['baseFlags'] ?? NONE;
         $docComment = $refClass->getDocComment();
 
         if ($docComment === false) {
@@ -242,7 +242,7 @@ REGEXP;
             file_get_contents($refClass->getFileName()),
             $docComment,
             $refGetDefaults->getClosure($refClass)(),
-            $defaultFlags
+            $baseFlags
         );
     }
 

--- a/src/MIGRATION_GUIDE.md
+++ b/src/MIGRATION_GUIDE.md
@@ -1,0 +1,19 @@
+# Migration Guide
+
+## Breaking Changes
+
+### Default flags property name changed
+
+`defualtFlags` property on `DataTransferObject` was renamed to `baseFlags`.
+
+All DTOs overriding "defaultFlags" need to update to override "baseFlags".
+
+### Default / base flags value changed
+
+`defaultFlags` value updated from `ARRAY_DEFAULT_TO_EMPTY_ARRAY | NULLABLE_DEFAULT_TO_NULL` to `NONE`.
+
+Existing DTOs that had overridden `defaultFlags` to `NONE` do no need updating.
+
+Existing DTOs inheriting the old `defaultFlags` 
+
+// TODO update with better advice once default values has been reworked.

--- a/src/MIGRATION_GUIDE.md
+++ b/src/MIGRATION_GUIDE.md
@@ -4,7 +4,7 @@
 
 ### Default flags property name changed
 
-`defualtFlags` property on `DataTransferObject` was renamed to `baseFlags`.
+`defaultFlags` property on `DataTransferObject` was renamed to `baseFlags`.
 
 All DTOs overriding "defaultFlags" need to update to override "baseFlags".
 

--- a/tests/Feature/NestableDtoTest.php
+++ b/tests/Feature/NestableDtoTest.php
@@ -7,6 +7,8 @@ use Rexlabs\DataTransferObject\DataTransferObject;
 use Rexlabs\DataTransferObject\Factory;
 use Rexlabs\DataTransferObject\Tests\Feature\Examples\TestingNestableDto;
 
+use const Rexlabs\DataTransferObject\PARTIAL;
+
 /**
  * Class NestableDtoTest
  * @package Rexlabs\DataTransferObject\Tests\Feature
@@ -73,7 +75,7 @@ class NestableDtoTest extends TestCase
                     'last_name' => 'Dirt',
                 ],
             ],
-        ]);
+        ], PARTIAL);
         $parent = $object->parent;
         $partner = $object->partner;
         $siblings = $object->siblings;

--- a/tests/Unit/DataTransferObjectTest.php
+++ b/tests/Unit/DataTransferObjectTest.php
@@ -12,10 +12,8 @@ use Rexlabs\DataTransferObject\Property;
 
 use function spl_object_id;
 
-use const Rexlabs\DataTransferObject\ARRAY_DEFAULT_TO_EMPTY_ARRAY;
 use const Rexlabs\DataTransferObject\MUTABLE;
 use const Rexlabs\DataTransferObject\NONE;
-use const Rexlabs\DataTransferObject\NULLABLE_DEFAULT_TO_NULL;
 
 /**
  * Class DataTransferObjectTest
@@ -242,11 +240,11 @@ class DataTransferObjectTest extends TestCase
      * @test
      * @return void
      */
-    public function default_flags_have_not_changed(): void
+    public function base_flags_have_not_changed(): void
     {
-        $expected = NULLABLE_DEFAULT_TO_NULL | ARRAY_DEFAULT_TO_EMPTY_ARRAY;
+        $expected = NONE;
         $refDto = new ReflectionClass(DataTransferObject::class);
-        $current = $refDto->getDefaultProperties()['defaultFlags'];
+        $current = $refDto->getDefaultProperties()['baseFlags'];
 
         self::assertEquals($expected, $current);
     }


### PR DESCRIPTION
### Issue

> The default flags feel a bit inappropriate. Personally feel the defaults should be NONE. I find it really weird that they also make the properties defined.

### Solution

- Change name of class default flags to "baseFlags"
- Change default to NONE
- Document better that they are combined with passed in flags
- changelog document migration steps

### Breaking change migration

- find every dto class in every project and if they haven't defined defaults, define the old defaults