### PR TITLE
1.0.0.-rc1-part-4: implicit simple defaults

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -299,7 +299,7 @@ class DataTransferObject
         $defaults = array_reduce(
             array_diff_key($this->propertyTypes, $this->getDefinedPropertyNames()),
             function (array $carry, Property $type): array {
-                foreach ($type->mapProcessedDefault($this->flags) as $name => $default) {
+                foreach ($type->mapProcessedDefault() as $name => $default) {
                     $carry[$name] = $default;
                 }
                 return $carry;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -182,8 +182,8 @@ REGEXP;
             // Set missing properties to defaults
             $defaults = array_reduce(
                 array_diff_key($types, $properties),
-                function (array $carry, Property $type) use ($flags): array {
-                    foreach ($type->mapProcessedDefault($flags) as $name => $default) {
+                function (array $carry, Property $type): array {
+                    foreach ($type->mapProcessedDefault() as $name => $default) {
                         $carry[$name] = $default;
                     }
                     return $carry;

--- a/src/Flags.php
+++ b/src/Flags.php
@@ -15,17 +15,8 @@ const TRACK_UNKNOWN_PROPERTIES     = 1 << 1;
 // Allow edits, objects are immutable by default
 const MUTABLE                      = 1 << 2;
 
-// Default properties with an array type to an empty array
-const ARRAY_DEFAULT_TO_EMPTY_ARRAY = 1 << 3;
-
-// Default nullable properties to null
-const NULLABLE_DEFAULT_TO_NULL     = 1 << 4;
-
-// Default properties with a boolean type to false
-const BOOL_DEFAULT_TO_FALSE        = 1 << 5;
-
 // Ignore requirements and defaults only filling what is provided
-const PARTIAL                      = 1 << 6;
+const PARTIAL                      = 1 << 3;
 
 // Define missing props using default values
-const DEFAULTS                     = 1 << 7;
+const DEFAULTS                     = 1 << 4;

--- a/src/Property.php
+++ b/src/Property.php
@@ -101,26 +101,27 @@ class Property
      * Return an array with default value keyed by name or empty array if no
      * default can be made
      *
-     * @param int $flags
      * @return array
      */
-    public function mapProcessedDefault(int $flags): array
+    public function mapProcessedDefault(): array
     {
         $defaults = [];
 
-        // Nullable first
-        if ($this->canDefaultToNull($flags)) {
-            $defaults[$this->name] = null;
+        // Order of default cascading is important
+        // Lower checks will override higher ones
+        // Generally preference is for the "least meaningful" value to win
+        // eg null will override false or empty array
+
+        if ($this->isArray) {
+            $defaults[$this->name] = [];
         }
 
-        // False next
-        if ($this->canDefaultToFalse($flags)) {
+        if ($this->isBool) {
             $defaults[$this->name] = false;
         }
 
-        // Empty array next
-        if ($this->canDefaultToArray($flags)) {
-            $defaults[$this->name] = [];
+        if ($this->isNullable) {
+            $defaults[$this->name] = null;
         }
 
         // Property default last
@@ -129,57 +130,6 @@ class Property
         }
 
         return $defaults;
-    }
-
-    /**
-     * @param int $flags
-     * @return bool
-     */
-    private function canDefaultToNull(int $flags): bool
-    {
-        if (!$this->isNullable) {
-            return false;
-        }
-
-        return (bool) ($flags & NULLABLE_DEFAULT_TO_NULL);
-    }
-
-    /**
-     * @param int $flags
-     * @return bool
-     */
-    private function canDefaultToFalse(int $flags): bool
-    {
-        if (!$this->isBool) {
-            return false;
-        }
-
-        return (bool) ($flags & BOOL_DEFAULT_TO_FALSE);
-    }
-
-    /**
-     * @param int $flags
-     * @return bool
-     */
-    private function canDefaultToArray(int $flags): bool
-    {
-        if (!$this->isArray) {
-            return false;
-        }
-
-        return (bool) ($flags & ARRAY_DEFAULT_TO_EMPTY_ARRAY);
-    }
-
-    /**
-     * Will always have a default of null, use mapProcessedDefault to determine
-     * if a default exists or not
-     *
-     * @param int $flags
-     * @return mixed
-     */
-    public function processDefault(int $flags)
-    {
-        return $this->mapProcessedDefault($flags)[$this->name] ?? null;
     }
 
     /**

--- a/tests/Unit/DefaultValuesTest.php
+++ b/tests/Unit/DefaultValuesTest.php
@@ -8,11 +8,8 @@ use Rexlabs\DataTransferObject\Exceptions\UninitialisedPropertiesError;
 use Rexlabs\DataTransferObject\Factory;
 use Rexlabs\DataTransferObject\Property;
 
-use const Rexlabs\DataTransferObject\ARRAY_DEFAULT_TO_EMPTY_ARRAY;
-use const Rexlabs\DataTransferObject\BOOL_DEFAULT_TO_FALSE;
 use const Rexlabs\DataTransferObject\DEFAULTS;
 use const Rexlabs\DataTransferObject\NONE;
-use const Rexlabs\DataTransferObject\NULLABLE_DEFAULT_TO_NULL;
 use const Rexlabs\DataTransferObject\PARTIAL;
 
 class DefaultValuesTest extends TestCase
@@ -232,7 +229,7 @@ class DefaultValuesTest extends TestCase
             ['one' => new Property($this->factory, 'one', ['null', 'string'], [], false, null)],
             DataTransferObject::class,
             [],
-            NULLABLE_DEFAULT_TO_NULL | DEFAULTS
+            DEFAULTS
         );
         $data = $object->toArray();
 
@@ -251,7 +248,7 @@ class DefaultValuesTest extends TestCase
             ['one' => new Property($this->factory, 'one', ['null', 'string'], [], false, null)],
             DataTransferObject::class,
             [],
-            PARTIAL | NULLABLE_DEFAULT_TO_NULL | DEFAULTS
+            PARTIAL | DEFAULTS
         );
 
         self::assertNull($object->__get('one'));
@@ -285,7 +282,7 @@ class DefaultValuesTest extends TestCase
             ['one' => new Property($this->factory, 'one', ['string'], [], false, null)],
             DataTransferObject::class,
             [],
-            NULLABLE_DEFAULT_TO_NULL | ARRAY_DEFAULT_TO_EMPTY_ARRAY
+            NONE
         );
     }
 
@@ -299,7 +296,7 @@ class DefaultValuesTest extends TestCase
             ['one' => new Property($this->factory, 'one', ['array'], [], false, null)],
             DataTransferObject::class,
             [],
-            NULLABLE_DEFAULT_TO_NULL | ARRAY_DEFAULT_TO_EMPTY_ARRAY | DEFAULTS
+            DEFAULTS
         );
 
 
@@ -316,7 +313,7 @@ class DefaultValuesTest extends TestCase
             ['one' => new Property($this->factory, 'one', ['bool'], [], false, null)],
             DataTransferObject::class,
             [],
-            BOOL_DEFAULT_TO_FALSE | DEFAULTS
+            DEFAULTS
         );
 
 
@@ -327,16 +324,16 @@ class DefaultValuesTest extends TestCase
      * @test
      * @return void
      */
-    public function empty_array_takes_precedence_over_nullable(): void
+    public function nullable_takes_precedence_over_empty_array(): void
     {
         $object = $this->factory->makeWithProperties(
             ['one' => new Property($this->factory, 'one', ['null', 'array'], [], false, null)],
             DataTransferObject::class,
             [],
-            NULLABLE_DEFAULT_TO_NULL | ARRAY_DEFAULT_TO_EMPTY_ARRAY | DEFAULTS
+            DEFAULTS
         );
 
-        self::assertEquals([], $object->__get('one'));
+        self::assertNull($object->__get('one'));
     }
 
     /**
@@ -349,7 +346,7 @@ class DefaultValuesTest extends TestCase
             ['one' => new Property($this->factory, 'one', ['null', 'array'], [], true, 'blim')],
             DataTransferObject::class,
             [],
-            NULLABLE_DEFAULT_TO_NULL | ARRAY_DEFAULT_TO_EMPTY_ARRAY | DEFAULTS
+            DEFAULTS
         );
 
 
@@ -382,7 +379,7 @@ class DefaultValuesTest extends TestCase
             ['blim' => new Property($this->factory, 'blim', ['string'], [], true, 'blam')],
             DataTransferObject::class,
             [],
-            NONE | DEFAULTS
+            DEFAULTS
         );
 
         self::assertEquals('blam', $object->__get('blim'));


### PR DESCRIPTION
#### Defaults should be implicit

Move defaults into implicit behavior, these flags effectively will always be on.
Null should take precedence over array.

- DEFAULT_NULL_TO_NULL
- DEFAULT_ARRAY_TO_EMPTY_ARRAY
- DEFAULT_BOOL_TO_FALSE