### PR TITLE
1.0.0-rc1-part-6: refactor make

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -73,9 +73,9 @@ class DataTransferObject
     public static function make(array $parameters, int $flags = NONE): self
     {
         $factory = self::getFactory();
-        $meta = $factory->getDTOMetadata(static::class);
+        $meta = $factory->getClassMetadata(static::class);
 
-        return $factory->makeWithPropertyTypes(
+        return $factory->make(
             $meta->class,
             $meta->propertyTypes,
             $parameters,

--- a/src/Exceptions/UninitialisedPropertiesError.php
+++ b/src/Exceptions/UninitialisedPropertiesError.php
@@ -15,13 +15,13 @@ class UninitialisedPropertiesError extends DataTransferObjectError
     /**
      * UninitialisedPropertiesError constructor.
      *
-     * @param array $properties
+     * @param array $propertyNames
      * @param string $objectClass
      * @param int $code
      * @param Throwable|null $previous
      */
     public function __construct(
-        array $properties,
+        array $propertyNames,
         string $objectClass,
         int $code = 0,
         Throwable $previous = null
@@ -30,12 +30,12 @@ class UninitialisedPropertiesError extends DataTransferObjectError
         parent::__construct(
             sprintf(
                 '%s %s from %s %s not been initialised.',
-                count($properties) === 1 ? 'Property' : 'Properties',
+                count($propertyNames) === 1 ? 'Property' : 'Properties',
                 implode('`, `', array_map(function (string $property): string {
                     return '"' . $property . '"';
-                }, $properties)),
+                }, $propertyNames)),
                 end($classParts),
-                count($properties) === 1 ? 'has' : 'have'
+                count($propertyNames) === 1 ? 'has' : 'have'
             ),
             $code,
             $previous

--- a/src/Exceptions/UnknownPropertiesError.php
+++ b/src/Exceptions/UnknownPropertiesError.php
@@ -15,17 +15,17 @@ class UnknownPropertiesError extends DataTransferObjectError
     /**
      * UnknownPropertiesError constructor.
      *
-     * @param array $properties
+     * @param array $propertyNames
      * @param int $code
      * @param Throwable|null $previous
      */
-    public function __construct(array $properties, int $code = 0, Throwable $previous = null)
+    public function __construct(array $propertyNames, int $code = 0, Throwable $previous = null)
     {
         parent::__construct(
             sprintf(
                 'Unknown %s `%s`',
-                count($properties) === 1 ? 'property' : 'properties',
-                implode('`, `', $properties)
+                count($propertyNames) === 1 ? 'property' : 'properties',
+                implode('`, `', $propertyNames)
             ),
             $code,
             $previous

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -75,26 +75,6 @@ REGEXP;
     }
 
     /**
-     * Make an instance of the requested DTO
-     *
-     * @param string $class
-     * @param array $parameters
-     * @param int $flags
-     * @return DataTransferObject
-     */
-    public function make(string $class, array $parameters, int $flags): DataTransferObject
-    {
-        $meta = $this->getDTOMetadata($class);
-
-        return $this->makeWithPropertyTypes(
-            $meta->propertyTypes,
-            $meta->class,
-            $parameters,
-            $meta->baseFlags | $flags
-        );
-    }
-
-    /**
      * Get DTOMetadata. Use a simple cache to ensure each class doc
      * is only parsed once
      *
@@ -145,73 +125,86 @@ REGEXP;
     }
 
     /**
-     * @param PropertyType[] $propertyTypes
+     * Make a valid dto instance ensuring:
+     *
+     *  - only "known" properties are used
+     *  - defaults are used if requested
+     *  - unknown properties are tracked if requested
+     *  - throw if unknown properties aren't requested to ignore or track
+     *  - create partial if requested
+     *  - throw when undefined properties and not partial
+     *
      * @param string $class
-     * @param array $parameters
+     * @param PropertyType[] $propertyTypes
+     * @param mixed[] $parameters
      * @param int $flags
      *
      * @return DataTransferObject
      */
-    public function makeWithPropertyTypes(
-        array $propertyTypes,
+    public function make(
         string $class,
+        array $propertyTypes,
         array $parameters,
         int $flags = NONE
     ): DataTransferObject {
+        // Sort properties by known and unknown
         $properties = [];
+        $unknownProperties = [];
         foreach ($parameters as $name => $value) {
             $propertyType = $propertyTypes[$name] ?? null;
-            if ($propertyType === null) {
-                // Ignore unknown types on lenient objects
-                if ($flags & (IGNORE_UNKNOWN_PROPERTIES | TRACK_UNKNOWN_PROPERTIES)) {
-                    continue;
-                }
 
-                throw new UnknownPropertiesError([$name]);
+            if ($propertyType === null) {
+                $unknownProperties[$name] = $value;
+                continue;
             }
 
             $properties[$name] = $this->processValue($propertyType, $value, $flags | MUTABLE);
         }
 
-        $unknownProperties = ($flags & TRACK_UNKNOWN_PROPERTIES)
-            ? array_diff_key($parameters, array_flip(array_keys($properties)))
-            : [];
-
-        // Only set defaults when explicitly requested
+        // Set defaults for uninitialised properties when explicitly requested
         if ($flags & DEFAULTS) {
             foreach ($propertyTypes as $propertyType) {
-                // Property already provided
+                // Defaults ignore properties already defined
                 if (array_key_exists($propertyType->getName(), $properties)) {
                     continue;
                 }
 
-                // Can't set defaults of the property type doesn't have one
+                // No default available to use
                 if (!$propertyType->hasValidDefault()) {
                     continue;
                 }
 
-                // Set the missing property to the default
+                // Set the undefined property to the default
                 $properties[$propertyType->getName()] = $propertyType->getDefault();
             }
         }
 
-        // Return before check for uninitialised properties for partial
-        if ($flags & PARTIAL) {
-            return new $class($propertyTypes, $properties, $flags);
-        }
+        // Track unknown properties if requested
+        $trackedUnknownProperties = ($flags & TRACK_UNKNOWN_PROPERTIES)
+            ? $unknownProperties
+            : [];
 
-        // Find properties that are still missing after defaults
-        $missing = array_diff(array_keys($propertyTypes), array_keys($properties));
-        if (count($missing) > 0) {
-            throw new UninitialisedPropertiesError($missing, $class);
+        // Throw unknown properties unless requested to track or ignore
+        if (!$flags & (IGNORE_UNKNOWN_PROPERTIES | TRACK_UNKNOWN_PROPERTIES) && count($unknownProperties) > 0) {
+            throw new UnknownPropertiesError(array_keys($unknownProperties));
         }
 
         /**
+         * @uses DataTransferObject::__construct
+         *
          * @var DataTransferObject $dto
          */
-        $dto = new $class($propertyTypes, $properties, $flags);
-        if ($flags & TRACK_UNKNOWN_PROPERTIES) {
-            $dto->setUnknownProperties($unknownProperties);
+        $dto = new $class($propertyTypes, $properties, $trackedUnknownProperties, $flags);
+
+        // Return before check for uninitialised properties for partial
+        if ($flags & PARTIAL) {
+            return $dto;
+        }
+
+        // Throw uninitialised properties
+        $undefined = $dto->getUndefinedPropertyNames();
+        if (count($undefined) > 0) {
+            throw new UninitialisedPropertiesError($undefined, $class);
         }
 
         return $dto;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -81,7 +81,7 @@ REGEXP;
      * @param string $class
      * @return DTOMetadata
      */
-    public function getDTOMetadata(string $class): DTOMetadata
+    public function getClassMetadata(string $class): DTOMetadata
     {
         $key = $this->getCacheKey('dto', $class, []);
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rexlabs\DataTransferObject;
 
+use InvalidArgumentException;
 use LogicException;
 use ReflectionClass;
 use ReflectionException;
@@ -423,6 +424,13 @@ REGEXP;
         array $allTypes,
         array $classDefaults = []
     ): PropertyType {
+        if (empty($allTypes)) {
+            throw new InvalidArgumentException(sprintf(
+                'At least one type must be defined for property: %s',
+                $name
+            ));
+        }
+
         $singleTypes = [];
         $arrayTypes = [];
         $isNullable = false;

--- a/src/FactoryContract.php
+++ b/src/FactoryContract.php
@@ -7,25 +7,26 @@ namespace Rexlabs\DataTransferObject;
 interface FactoryContract
 {
     /**
-     * Make an instance of the requested DTO
-     *
-     * @param string $class
-     * @param array $parameters
-     * @param int $flags
-     * @return DataTransferObject
-     */
-    public function make(
-        string $class,
-        array $parameters,
-        int $flags
-    ): DataTransferObject;
-
-    /**
      * Get DTOMetadata. Use a simple cache to ensure each class doc
      * is only parsed once
      *
      * @param string $class
      * @return DTOMetadata
      */
-    public function getDTOMetadata(string $class): DTOMetadata;
+    public function getClassMetadata(string $class): DTOMetadata;
+
+    /**
+     * @param string $class
+     * @param PropertyType[] $propertyTypes
+     * @param mixed[] $parameters
+     * @param int $flags
+     *
+     * @return DataTransferObject
+     */
+    public function make(
+        string $class,
+        array $propertyTypes,
+        array $parameters,
+        int $flags = NONE
+    ): DataTransferObject;
 }

--- a/tests/IssetIsDefinedTest.php
+++ b/tests/IssetIsDefinedTest.php
@@ -5,12 +5,26 @@ namespace Rexlabs\DataTransferObject\Tests;
 use PHPUnit\Framework\TestCase;
 use Rexlabs\DataTransferObject\DataTransferObject;
 use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesError;
+use Rexlabs\DataTransferObject\Factory;
 use Rexlabs\DataTransferObject\PropertyType;
 
 use const Rexlabs\DataTransferObject\NONE;
 
 class IssetIsDefinedTest extends TestCase
 {
+    /** @var Factory */
+    private $factory;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Factory([]);
+    }
+
     /**
      * @return void
      */
@@ -30,7 +44,7 @@ class IssetIsDefinedTest extends TestCase
     public function defined_property_returns_isset_true(): void
     {
         $object = new DataTransferObject(
-            ['blim' => $this->createMock(PropertyType::class)],
+            ['blim' => $this->factory->makePropertyType('blim', ['bool'])],
             ['blim' => true],
             NONE
         );
@@ -47,7 +61,7 @@ class IssetIsDefinedTest extends TestCase
     public function defined_null_value_property_returns_isset_false(): void
     {
         $object = new DataTransferObject(
-            ['blim' => $this->createMock(PropertyType::class)],
+            ['blim' => $this->factory->makePropertyType('blim', ['null'])],
             ['blim' => null],
             NONE
         );
@@ -63,8 +77,8 @@ class IssetIsDefinedTest extends TestCase
     {
         $object = new DataTransferObject(
             [
-                'blim' => $this->createMock(PropertyType::class),
-                'blam' => $this->createMock(PropertyType::class),
+                'blim' => $this->factory->makePropertyType('blim', ['null']),
+                'blam' => $this->factory->makePropertyType('blam', ['bool']),
             ],
             [
                 'blim' => null,
@@ -84,11 +98,11 @@ class IssetIsDefinedTest extends TestCase
     public function is_defined_supports_dot_notation_for_nested_properties(): void
     {
         $object = new DataTransferObject(
-            ['blim' => $this->createMock(PropertyType::class)],
+            ['blim' => $this->factory->makePropertyType('blim', ['mixed'])],
             ['blim' => new DataTransferObject(
-                ['blam' => $this->createMock(PropertyType::class)],
+                ['blam' => $this->factory->makePropertyType('blam', ['mixed'])],
                 ['blam' => new DataTransferObject(
-                    ['beep' => $this->createMock(PropertyType::class)],
+                    ['beep' => $this->factory->makePropertyType('beep', ['mixed'])],
                     ['beep' => true],
                     NONE
                 )],
@@ -107,7 +121,7 @@ class IssetIsDefinedTest extends TestCase
     public function undefined_property_returns_is_defined_false(): void
     {
         $object = new DataTransferObject(
-            ['blim' => $this->createMock(PropertyType::class)],
+            ['blim' => $this->factory->makePropertyType('blim', ['null'])],
             [],
             NONE
         );
@@ -124,7 +138,7 @@ class IssetIsDefinedTest extends TestCase
         $this->expectException(UnknownPropertiesError::class);
 
         $object = new DataTransferObject(
-            ['blim' => $this->createMock(PropertyType::class)],
+            ['blim' => $this->factory->makePropertyType('blim', ['null'])],
             [],
             NONE
         );

--- a/tests/IssetIsDefinedTest.php
+++ b/tests/IssetIsDefinedTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 use Rexlabs\DataTransferObject\DataTransferObject;
 use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesError;
 use Rexlabs\DataTransferObject\Factory;
-use Rexlabs\DataTransferObject\PropertyType;
 
 use const Rexlabs\DataTransferObject\NONE;
 

--- a/tests/IssetIsDefinedTest.php
+++ b/tests/IssetIsDefinedTest.php
@@ -45,6 +45,7 @@ class IssetIsDefinedTest extends TestCase
         $object = new DataTransferObject(
             ['blim' => $this->factory->makePropertyType('blim', ['bool'])],
             ['blim' => true],
+            [],
             NONE
         );
 
@@ -62,6 +63,7 @@ class IssetIsDefinedTest extends TestCase
         $object = new DataTransferObject(
             ['blim' => $this->factory->makePropertyType('blim', ['null'])],
             ['blim' => null],
+            [],
             NONE
         );
 
@@ -80,9 +82,10 @@ class IssetIsDefinedTest extends TestCase
                 'blam' => $this->factory->makePropertyType('blam', ['bool']),
             ],
             [
-                'blim' => null,
-                'blam' => true
+            'blim' => null,
+            'blam' => true
             ],
+            [],
             NONE
         );
 
@@ -98,15 +101,22 @@ class IssetIsDefinedTest extends TestCase
     {
         $object = new DataTransferObject(
             ['blim' => $this->factory->makePropertyType('blim', ['mixed'])],
-            ['blim' => new DataTransferObject(
-                ['blam' => $this->factory->makePropertyType('blam', ['mixed'])],
-                ['blam' => new DataTransferObject(
-                    ['beep' => $this->factory->makePropertyType('beep', ['mixed'])],
-                    ['beep' => true],
+            [
+                'blim' => new DataTransferObject(
+                    ['blam' => $this->factory->makePropertyType('blam', ['mixed'])],
+                    [
+                        'blam' => new DataTransferObject(
+                            ['beep' => $this->factory->makePropertyType('beep', ['mixed'])],
+                            ['beep' => true],
+                            [],
+                            NONE
+                        )
+                    ],
+                    [],
                     NONE
-                )],
-                NONE
-            )],
+                )
+            ],
+            [],
             NONE
         );
 
@@ -121,6 +131,7 @@ class IssetIsDefinedTest extends TestCase
     {
         $object = new DataTransferObject(
             ['blim' => $this->factory->makePropertyType('blim', ['null'])],
+            [],
             [],
             NONE
         );
@@ -138,6 +149,7 @@ class IssetIsDefinedTest extends TestCase
 
         $object = new DataTransferObject(
             ['blim' => $this->factory->makePropertyType('blim', ['null'])],
+            [],
             [],
             NONE
         );

--- a/tests/Unit/DataTransferObjectTest.php
+++ b/tests/Unit/DataTransferObjectTest.php
@@ -63,7 +63,7 @@ class DataTransferObjectTest extends TestCase
     public function access_property_if_defined(): void
     {
         $object = new DataTransferObject(
-            ['one' => $this->factory->makePropertyType('one', [])],
+            ['one' => $this->factory->makePropertyType('one', ['string'])],
             ['one' => 'value'],
             NONE
         );
@@ -82,7 +82,7 @@ class DataTransferObjectTest extends TestCase
         $factory->method('processValue')->willReturn('processed_value');
 
         $object = new DataTransferObject(
-            ['blim' => $factory->makePropertyType('blim', [])],
+            ['blim' => $factory->makePropertyType('blim', ['string'])],
             [],
             MUTABLE
         );

--- a/tests/Unit/DataTransferObjectTest.php
+++ b/tests/Unit/DataTransferObjectTest.php
@@ -65,6 +65,7 @@ class DataTransferObjectTest extends TestCase
         $object = new DataTransferObject(
             ['one' => $this->factory->makePropertyType('one', ['string'])],
             ['one' => 'value'],
+            [],
             NONE
         );
 
@@ -83,6 +84,7 @@ class DataTransferObjectTest extends TestCase
 
         $object = new DataTransferObject(
             ['blim' => $factory->makePropertyType('blim', ['string'])],
+            [],
             [],
             MUTABLE
         );
@@ -114,20 +116,35 @@ class DataTransferObjectTest extends TestCase
      */
     public function to_array_handles_arrays_of_to_array_items(): void
     {
-        $itemOne =  new DataTransferObject([], [
+        $itemOne =  new DataTransferObject(
+            [],
+            [
             'one' => 1,
             'two' => 2,
-        ], NONE);
-        $itemTwo =  new DataTransferObject([], [
+            ],
+            [],
+            NONE
+        );
+        $itemTwo =  new DataTransferObject(
+            [],
+            [
             'one' => 1,
             'two' => 2,
-        ], NONE);
-        $parent = new DataTransferObject([], [
+            ],
+            [],
+            NONE
+        );
+        $parent = new DataTransferObject(
+            [],
+            [
             'data' => [
                 $itemOne,
                 $itemTwo,
             ]
-        ], NONE);
+            ],
+            [],
+            NONE
+        );
 
         $expected = [
             'data' => [

--- a/tests/Unit/DefaultValuesTest.php
+++ b/tests/Unit/DefaultValuesTest.php
@@ -54,7 +54,7 @@ class DefaultValuesTest extends TestCase
         $this->expectException(UninitialisedPropertiesError::class);
 
         // Missing properties have default values
-        $this->factory->makeWithPropertyTypes(
+        $this->factory->make(
             DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [
@@ -87,7 +87,7 @@ class DefaultValuesTest extends TestCase
         ];
 
         // Missing properties have default values
-        $dto = $this->factory->makeWithPropertyTypes(
+        $dto = $this->factory->make(
             DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [
@@ -123,7 +123,7 @@ class DefaultValuesTest extends TestCase
         ];
 
         // Missing properties have default values
-        $dto = $this->factory->makeWithPropertyTypes(
+        $dto = $this->factory->make(
             DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [
@@ -160,7 +160,7 @@ class DefaultValuesTest extends TestCase
         ];
 
         // Missing properties have default values
-        $dto = $this->factory->makeWithPropertyTypes(
+        $dto = $this->factory->make(
             DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [
@@ -196,7 +196,7 @@ class DefaultValuesTest extends TestCase
         ];
 
         // Missing properties have default values
-        $dto = $this->factory->makeWithPropertyTypes(
+        $dto = $this->factory->make(
             DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [
@@ -232,7 +232,7 @@ class DefaultValuesTest extends TestCase
         ];
 
         // Missing properties have default values
-        $dto = $this->factory->makeWithPropertyTypes(
+        $dto = $this->factory->make(
             DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [
@@ -260,7 +260,7 @@ class DefaultValuesTest extends TestCase
      */
     public function undefined_nullable_property_with_defaults_returns_null(): void
     {
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             ['one' => $this->factory->makePropertyType('one', ['null', 'string'])],
             [],
@@ -278,7 +278,7 @@ class DefaultValuesTest extends TestCase
      */
     public function undefined_nullable_property_omitted_by_to_array(): void
     {
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             ['one' => $this->factory->makePropertyType('one', ['null', 'string'])],
             [],
@@ -296,7 +296,7 @@ class DefaultValuesTest extends TestCase
     {
         $this->expectException(UninitialisedPropertiesError::class);
 
-        $this->factory->makeWithPropertyTypes(
+        $this->factory->make(
             DataTransferObject::class,
             ['one' => $this->factory->makePropertyType('one', ['string'])],
             [],
@@ -310,7 +310,7 @@ class DefaultValuesTest extends TestCase
      */
     public function array_defaults_to_empty_array_with_defaults(): void
     {
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             ['one' => $this->factory->makePropertyType('one', ['array'])],
             [],
@@ -326,7 +326,7 @@ class DefaultValuesTest extends TestCase
      */
     public function bool_defaults_to_false_with_defaults(): void
     {
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             ['one' => $this->factory->makePropertyType('one', ['bool'])],
             [],
@@ -343,7 +343,7 @@ class DefaultValuesTest extends TestCase
      */
     public function nullable_takes_precedence_over_empty_array(): void
     {
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             ['one' => $this->factory->makePropertyType('one', ['null', 'array'])],
             [],
@@ -359,7 +359,7 @@ class DefaultValuesTest extends TestCase
      */
     public function default_takes_precedence_over_nullable_or_empty_array(): void
     {
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             ['one' => $this->factory->makePropertyType('one', ['null', 'array'], ['one' => 'blim'])],
             [],
@@ -378,7 +378,7 @@ class DefaultValuesTest extends TestCase
     {
         $this->expectException(UninitialisedPropertiesError::class);
 
-        $this->factory->makeWithPropertyTypes(
+        $this->factory->make(
             DataTransferObject::class,
             ['one' => $this->factory->makePropertyType('one', ['null', 'array', 'bool'])],
             [],
@@ -392,7 +392,7 @@ class DefaultValuesTest extends TestCase
      */
     public function undefined_property_reverts_to_default(): void
     {
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             ['blim' => $this->factory->makePropertyType('blim', ['string'], ['blim' => 'blam'])],
             [],

--- a/tests/Unit/DefaultValuesTest.php
+++ b/tests/Unit/DefaultValuesTest.php
@@ -245,7 +245,6 @@ class DefaultValuesTest extends TestCase
                     'four' => '',
                 ]
             ),
-
             DataTransferObject::class,
             $properties,
             DEFAULTS

--- a/tests/Unit/DefaultValuesTest.php
+++ b/tests/Unit/DefaultValuesTest.php
@@ -45,7 +45,7 @@ class DefaultValuesTest extends TestCase
      */
     public function defaults_not_set_without_flag(): void
     {
-        // Missing two parameters
+        // Missing two parameters that can have defaults
         $properties = [
             'one' => 'one',
             'two' => 'two',
@@ -55,6 +55,7 @@ class DefaultValuesTest extends TestCase
 
         // Missing properties have default values
         $this->factory->makeWithPropertyTypes(
+            DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [
                     'one' => ['string'],
@@ -67,7 +68,6 @@ class DefaultValuesTest extends TestCase
                     'four' => '',
                 ]
             ),
-            DataTransferObject::class,
             $properties,
             NONE
         );
@@ -88,6 +88,7 @@ class DefaultValuesTest extends TestCase
 
         // Missing properties have default values
         $dto = $this->factory->makeWithPropertyTypes(
+            DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [
                     'one' => ['string'],
@@ -100,7 +101,6 @@ class DefaultValuesTest extends TestCase
                     'four' => '',
                 ]
             ),
-            DataTransferObject::class,
             $properties,
             PARTIAL
         );
@@ -124,6 +124,7 @@ class DefaultValuesTest extends TestCase
 
         // Missing properties have default values
         $dto = $this->factory->makeWithPropertyTypes(
+            DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [
                     'one' => ['string'],
@@ -136,7 +137,6 @@ class DefaultValuesTest extends TestCase
                     'four' => '',
                 ]
             ),
-            DataTransferObject::class,
             $properties,
             PARTIAL
         );
@@ -161,6 +161,7 @@ class DefaultValuesTest extends TestCase
 
         // Missing properties have default values
         $dto = $this->factory->makeWithPropertyTypes(
+            DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [
                     'one' => ['string'],
@@ -173,7 +174,6 @@ class DefaultValuesTest extends TestCase
                     'four' => '',
                 ]
             ),
-            DataTransferObject::class,
             $properties,
             PARTIAL | DEFAULTS
         );
@@ -197,6 +197,7 @@ class DefaultValuesTest extends TestCase
 
         // Missing properties have default values
         $dto = $this->factory->makeWithPropertyTypes(
+            DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [
                     'one' => ['string'],
@@ -209,7 +210,6 @@ class DefaultValuesTest extends TestCase
                     'four' => '',
                 ]
             ),
-            DataTransferObject::class,
             $properties,
             DEFAULTS
         );
@@ -233,6 +233,7 @@ class DefaultValuesTest extends TestCase
 
         // Missing properties have default values
         $dto = $this->factory->makeWithPropertyTypes(
+            DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [
                     'one' => ['string'],
@@ -245,7 +246,6 @@ class DefaultValuesTest extends TestCase
                     'four' => '',
                 ]
             ),
-            DataTransferObject::class,
             $properties,
             DEFAULTS
         );
@@ -261,8 +261,8 @@ class DefaultValuesTest extends TestCase
     public function undefined_nullable_property_with_defaults_returns_null(): void
     {
         $object = $this->factory->makeWithPropertyTypes(
-            ['one' => $this->factory->makePropertyType('one', ['null', 'string'])],
             DataTransferObject::class,
+            ['one' => $this->factory->makePropertyType('one', ['null', 'string'])],
             [],
             DEFAULTS
         );
@@ -279,8 +279,8 @@ class DefaultValuesTest extends TestCase
     public function undefined_nullable_property_omitted_by_to_array(): void
     {
         $object = $this->factory->makeWithPropertyTypes(
-            ['one' => $this->factory->makePropertyType('one', ['null', 'string'])],
             DataTransferObject::class,
+            ['one' => $this->factory->makePropertyType('one', ['null', 'string'])],
             [],
             PARTIAL
         );
@@ -297,8 +297,8 @@ class DefaultValuesTest extends TestCase
         $this->expectException(UninitialisedPropertiesError::class);
 
         $this->factory->makeWithPropertyTypes(
-            ['one' => $this->factory->makePropertyType('one', ['string'])],
             DataTransferObject::class,
+            ['one' => $this->factory->makePropertyType('one', ['string'])],
             [],
             NONE
         );
@@ -311,8 +311,8 @@ class DefaultValuesTest extends TestCase
     public function array_defaults_to_empty_array_with_defaults(): void
     {
         $object = $this->factory->makeWithPropertyTypes(
-            ['one' => $this->factory->makePropertyType('one', ['array'])],
             DataTransferObject::class,
+            ['one' => $this->factory->makePropertyType('one', ['array'])],
             [],
             DEFAULTS
         );
@@ -327,8 +327,8 @@ class DefaultValuesTest extends TestCase
     public function bool_defaults_to_false_with_defaults(): void
     {
         $object = $this->factory->makeWithPropertyTypes(
-            ['one' => $this->factory->makePropertyType('one', ['bool'])],
             DataTransferObject::class,
+            ['one' => $this->factory->makePropertyType('one', ['bool'])],
             [],
             DEFAULTS
         );
@@ -344,8 +344,8 @@ class DefaultValuesTest extends TestCase
     public function nullable_takes_precedence_over_empty_array(): void
     {
         $object = $this->factory->makeWithPropertyTypes(
-            ['one' => $this->factory->makePropertyType('one', ['null', 'array'])],
             DataTransferObject::class,
+            ['one' => $this->factory->makePropertyType('one', ['null', 'array'])],
             [],
             DEFAULTS
         );
@@ -360,8 +360,8 @@ class DefaultValuesTest extends TestCase
     public function default_takes_precedence_over_nullable_or_empty_array(): void
     {
         $object = $this->factory->makeWithPropertyTypes(
-            ['one' => $this->factory->makePropertyType('one', ['null', 'array'], ['one' => 'blim'])],
             DataTransferObject::class,
+            ['one' => $this->factory->makePropertyType('one', ['null', 'array'], ['one' => 'blim'])],
             [],
             DEFAULTS
         );
@@ -379,8 +379,8 @@ class DefaultValuesTest extends TestCase
         $this->expectException(UninitialisedPropertiesError::class);
 
         $this->factory->makeWithPropertyTypes(
-            ['one' => $this->factory->makePropertyType('one', ['null', 'array', 'bool'])],
             DataTransferObject::class,
+            ['one' => $this->factory->makePropertyType('one', ['null', 'array', 'bool'])],
             [],
             NONE
         );
@@ -393,8 +393,8 @@ class DefaultValuesTest extends TestCase
     public function undefined_property_reverts_to_default(): void
     {
         $object = $this->factory->makeWithPropertyTypes(
-            ['blim' => $this->factory->makePropertyType('blim', ['string'], ['blim' => 'blam'])],
             DataTransferObject::class,
+            ['blim' => $this->factory->makePropertyType('blim', ['string'], ['blim' => 'blam'])],
             [],
             DEFAULTS
         );

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -55,7 +55,7 @@ class FactoryTest extends TestCase
 
         $factory = new Factory(['dto_classOne' => $meta]);
 
-        $newMeta = $factory->getDTOMetadata('classOne');
+        $newMeta = $factory->getClassMetadata('classOne');
 
         self::assertEquals(spl_object_id($meta), spl_object_id($newMeta));
     }
@@ -73,7 +73,7 @@ class FactoryTest extends TestCase
             'nullable' => null,
         ];
 
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -74,13 +74,15 @@ class FactoryTest extends TestCase
         ];
 
         $object = $this->factory->makeWithPropertyTypes(
-            $this->factory->makePropertyTypes([
-                'one' => ['string'],
-                'two' => ['string'],
-                'three' => ['string'],
-                'nullable' => ['null', 'string'],
-            ]),
             DataTransferObject::class,
+            $this->factory->makePropertyTypes(
+                [
+                    'one' => ['string'],
+                    'two' => ['string'],
+                    'three' => ['string'],
+                    'nullable' => ['null', 'string'],
+                ]
+            ),
             $properties,
             NONE
         );

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rexlabs\DataTransferObject\Tests\Unit;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Rexlabs\DataTransferObject\DataTransferObject;
 use Rexlabs\DataTransferObject\DTOMetadata;
@@ -85,5 +86,16 @@ class FactoryTest extends TestCase
         );
 
         self::assertEquals($object->getDefinedProperties(), $properties);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function properties_must_have_at_least_one_type(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->factory->makePropertyType('', []);
     }
 }

--- a/tests/Unit/MutableTest.php
+++ b/tests/Unit/MutableTest.php
@@ -45,7 +45,7 @@ class MutableTest extends TestCase
     {
         $this->expectException(ImmutableError::class);
 
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             ['one' => $this->factory->makePropertyType('one', ['null', 'string'])],
             ['one' => 'One'],
@@ -63,7 +63,7 @@ class MutableTest extends TestCase
     {
         $newValue = 'mutation';
 
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             ['one' => $this->factory->makePropertyType('one', ['null', 'string'])],
             ['one' => 'One'],

--- a/tests/Unit/MutableTest.php
+++ b/tests/Unit/MutableTest.php
@@ -46,8 +46,8 @@ class MutableTest extends TestCase
         $this->expectException(ImmutableError::class);
 
         $object = $this->factory->makeWithPropertyTypes(
-            ['one' => $this->factory->makePropertyType('one', ['null', 'string'])],
             DataTransferObject::class,
+            ['one' => $this->factory->makePropertyType('one', ['null', 'string'])],
             ['one' => 'One'],
             NONE
         );
@@ -64,8 +64,8 @@ class MutableTest extends TestCase
         $newValue = 'mutation';
 
         $object = $this->factory->makeWithPropertyTypes(
-            ['one' => $this->factory->makePropertyType('one', ['null', 'string'])],
             DataTransferObject::class,
+            ['one' => $this->factory->makePropertyType('one', ['null', 'string'])],
             ['one' => 'One'],
             MUTABLE
         );

--- a/tests/Unit/PartialTest.php
+++ b/tests/Unit/PartialTest.php
@@ -41,7 +41,7 @@ class PartialTest extends TestCase
      */
     public function can_make_partial_without_required_fields(): void
     {
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             ['one' => $this->factory->makePropertyType('one', ['string'])],
             [],
@@ -58,7 +58,7 @@ class PartialTest extends TestCase
     public function partial_to_array_returns_only_defined(): void
     {
         $data = ['one' => 1];
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [
@@ -82,7 +82,7 @@ class PartialTest extends TestCase
     public function partial_get_properties_returns_only_defined(): void
     {
         $data = ['one' => 1];
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             $this->factory->makePropertyTypes(
                 [

--- a/tests/Unit/PartialTest.php
+++ b/tests/Unit/PartialTest.php
@@ -42,9 +42,8 @@ class PartialTest extends TestCase
     public function can_make_partial_without_required_fields(): void
     {
         $object = $this->factory->makeWithPropertyTypes(
-            ['one' => $this->factory->makePropertyType('one', ['string'])],
-            // ['one' => new PropertyType('one', ['string'], false, null)],
             DataTransferObject::class,
+            ['one' => $this->factory->makePropertyType('one', ['string'])],
             [],
             PARTIAL
         );
@@ -60,11 +59,14 @@ class PartialTest extends TestCase
     {
         $data = ['one' => 1];
         $object = $this->factory->makeWithPropertyTypes(
-            $this->factory->makePropertyTypes([
-                'one' => ['int'],
-                'two' => ['string', 'bool'],
-            ], ['two' => true]),
             DataTransferObject::class,
+            $this->factory->makePropertyTypes(
+                [
+                    'one' => ['int'],
+                    'two' => ['string', 'bool'],
+                ],
+                ['two' => true]
+            ),
             $data,
             PARTIAL
         );
@@ -81,11 +83,14 @@ class PartialTest extends TestCase
     {
         $data = ['one' => 1];
         $object = $this->factory->makeWithPropertyTypes(
-            $this->factory->makePropertyTypes([
-                'one' => ['int'],
-                'two' => ['string', 'bool'],
-            ], ['two' => true]),
             DataTransferObject::class,
+            $this->factory->makePropertyTypes(
+                [
+                    'one' => ['int'],
+                    'two' => ['string', 'bool'],
+                ],
+                ['two' => true]
+            ),
             $data,
             PARTIAL
         );

--- a/tests/Unit/PropertyAccessTest.php
+++ b/tests/Unit/PropertyAccessTest.php
@@ -5,7 +5,6 @@ namespace Rexlabs\DataTransferObject\Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use Rexlabs\DataTransferObject\DataTransferObject;
 use Rexlabs\DataTransferObject\Factory;
-use Rexlabs\DataTransferObject\PropertyType;
 
 use const Rexlabs\DataTransferObject\PARTIAL;
 

--- a/tests/Unit/PropertyAccessTest.php
+++ b/tests/Unit/PropertyAccessTest.php
@@ -55,6 +55,7 @@ class PropertyAccessTest extends TestCase
                 'flam' => $this->factory->makePropertyType('flam', ['null']),
             ],
             $values,
+            [],
             PARTIAL
         );
 
@@ -70,16 +71,19 @@ class PropertyAccessTest extends TestCase
     {
         $factory = new Factory([]);
         $dto = new DataTransferObject(
-            $factory->makePropertyTypes([
-                'blim' => ['null'],
-                'blam' => ['null'],
-                'flim' => ['array'],
-                'flam' => ['null', 'array'],
-            ]),
+            $factory->makePropertyTypes(
+                [
+                    'blim' => ['null'],
+                    'blam' => ['null'],
+                    'flim' => ['array'],
+                    'flam' => ['null', 'array'],
+                ]
+            ),
             [
-                'blim' => 'test',
-                'blam' => true
+            'blim' => 'test',
+            'blam' => true
             ],
+            [],
             PARTIAL
         );
 
@@ -102,16 +106,19 @@ class PropertyAccessTest extends TestCase
     {
         $factory = new Factory([]);
         $dto = new DataTransferObject(
-            $factory->makePropertyTypes([
-                'blim' => ['null'],
-                'blam' => ['null'],
-                'flim' => ['array'],
-                'flam' => ['null', 'array'],
-            ]),
+            $factory->makePropertyTypes(
+                [
+                    'blim' => ['null'],
+                    'blam' => ['null'],
+                    'flim' => ['array'],
+                    'flam' => ['null', 'array'],
+                ]
+            ),
             [
-                'blim' => 'test',
-                'blam' => true
+            'blim' => 'test',
+            'blam' => true
             ],
+            [],
             PARTIAL
         );
 
@@ -132,16 +139,19 @@ class PropertyAccessTest extends TestCase
     {
         $factory = new Factory([]);
         $dto = new DataTransferObject(
-            $factory->makePropertyTypes([
-                'blim' => ['null'],
-                'blam' => ['null'],
-                'flim' => ['array'],
-                'flam' => ['null', 'array'],
-            ]),
+            $factory->makePropertyTypes(
+                [
+                    'blim' => ['null'],
+                    'blam' => ['null'],
+                    'flim' => ['array'],
+                    'flam' => ['null', 'array'],
+                ]
+            ),
             [
-                'blim' => 'test',
-                'blam' => true
+            'blim' => 'test',
+            'blam' => true
             ],
+            [],
             PARTIAL
         );
 

--- a/tests/Unit/PropertyAccessTest.php
+++ b/tests/Unit/PropertyAccessTest.php
@@ -11,6 +11,19 @@ use const Rexlabs\DataTransferObject\PARTIAL;
 
 class PropertyAccessTest extends TestCase
 {
+    /** @var Factory */
+    private $factory;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Factory([]);
+    }
+
     /**
      * @return void
      */
@@ -37,10 +50,10 @@ class PropertyAccessTest extends TestCase
 
         $dto = new DataTransferObject(
             [
-                'blim' => $this->createMock(PropertyType::class),
-                'blam' => $this->createMock(PropertyType::class),
-                'flim' => $this->createMock(PropertyType::class),
-                'flam' => $this->createMock(PropertyType::class),
+                'blim' => $this->factory->makePropertyType('blim', ['null']),
+                'blam' => $this->factory->makePropertyType('blam', ['null']),
+                'flim' => $this->factory->makePropertyType('flim', ['null']),
+                'flam' => $this->factory->makePropertyType('flam', ['null']),
             ],
             $values,
             PARTIAL
@@ -59,8 +72,8 @@ class PropertyAccessTest extends TestCase
         $factory = new Factory([]);
         $dto = new DataTransferObject(
             $factory->makePropertyTypes([
-                'blim' => [],
-                'blam' => [],
+                'blim' => ['null'],
+                'blam' => ['null'],
                 'flim' => ['array'],
                 'flam' => ['null', 'array'],
             ]),
@@ -91,8 +104,8 @@ class PropertyAccessTest extends TestCase
         $factory = new Factory([]);
         $dto = new DataTransferObject(
             $factory->makePropertyTypes([
-                'blim' => [],
-                'blam' => [],
+                'blim' => ['null'],
+                'blam' => ['null'],
                 'flim' => ['array'],
                 'flam' => ['null', 'array'],
             ]),
@@ -121,8 +134,8 @@ class PropertyAccessTest extends TestCase
         $factory = new Factory([]);
         $dto = new DataTransferObject(
             $factory->makePropertyTypes([
-                'blim' => [],
-                'blam' => [],
+                'blim' => ['null'],
+                'blam' => ['null'],
                 'flim' => ['array'],
                 'flam' => ['null', 'array'],
             ]),

--- a/tests/Unit/UnknownPropertiesTest.php
+++ b/tests/Unit/UnknownPropertiesTest.php
@@ -38,6 +38,7 @@ class UnknownPropertiesTest extends TestCase
         // Also I'm sorry for caching static data
         DataTransferObject::setFactory(null);
     }
+
     /**
      * @test
      * @return void

--- a/tests/Unit/UnknownPropertiesTest.php
+++ b/tests/Unit/UnknownPropertiesTest.php
@@ -47,7 +47,7 @@ class UnknownPropertiesTest extends TestCase
     {
         $this->expectException(UnknownPropertiesError::class);
 
-        $object = new DataTransferObject([], [], NONE);
+        $object = new DataTransferObject([], [], [], NONE);
 
         $object->__get('blim');
     }
@@ -60,7 +60,7 @@ class UnknownPropertiesTest extends TestCase
     {
         $this->expectException(UnknownPropertiesError::class);
 
-        $object = new DataTransferObject([], [], MUTABLE);
+        $object = new DataTransferObject([], [], [], MUTABLE);
 
         $object->__set('blim', 'blam');
     }
@@ -74,8 +74,8 @@ class UnknownPropertiesTest extends TestCase
         $this->expectException(UnknownPropertiesError::class);
 
         $this->factory->makeWithPropertyTypes(
-            [],
             DataTransferObject::class,
+            [],
             ['blim' => 'blam'],
             NONE
         );
@@ -88,8 +88,8 @@ class UnknownPropertiesTest extends TestCase
     public function additional_properties_ignored_with_ignore_flags(): void
     {
         $object = $this->factory->makeWithPropertyTypes(
-            [],
             DataTransferObject::class,
+            [],
             ['blim' => 'blam'],
             IGNORE_UNKNOWN_PROPERTIES
         );
@@ -104,8 +104,8 @@ class UnknownPropertiesTest extends TestCase
     public function additional_properties_ignored_with_track_flag(): void
     {
         $object = $this->factory->makeWithPropertyTypes(
-            [],
             DataTransferObject::class,
+            [],
             ['blim' => 'blam'],
             TRACK_UNKNOWN_PROPERTIES
         );
@@ -122,8 +122,8 @@ class UnknownPropertiesTest extends TestCase
     {
         $unknownProperties = ['blim' => 'blam'];
         $object = $this->factory->makeWithPropertyTypes(
-            [],
             DataTransferObject::class,
+            [],
             $unknownProperties,
             IGNORE_UNKNOWN_PROPERTIES
         );
@@ -141,8 +141,8 @@ class UnknownPropertiesTest extends TestCase
     {
         $unknownProperties = ['blim' => 'blam'];
         $object = $this->factory->makeWithPropertyTypes(
-            [],
             DataTransferObject::class,
+            [],
             $unknownProperties,
             TRACK_UNKNOWN_PROPERTIES
         );
@@ -159,8 +159,8 @@ class UnknownPropertiesTest extends TestCase
     public function can_query_unknown_property_names_with_track_flag(): void
     {
         $object = $this->factory->makeWithPropertyTypes(
-            [],
             DataTransferObject::class,
+            [],
             ['blim' => 'blam'],
             TRACK_UNKNOWN_PROPERTIES
         );

--- a/tests/Unit/UnknownPropertiesTest.php
+++ b/tests/Unit/UnknownPropertiesTest.php
@@ -73,7 +73,7 @@ class UnknownPropertiesTest extends TestCase
     {
         $this->expectException(UnknownPropertiesError::class);
 
-        $this->factory->makeWithPropertyTypes(
+        $this->factory->make(
             DataTransferObject::class,
             [],
             ['blim' => 'blam'],
@@ -87,7 +87,7 @@ class UnknownPropertiesTest extends TestCase
      */
     public function additional_properties_ignored_with_ignore_flags(): void
     {
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             [],
             ['blim' => 'blam'],
@@ -103,7 +103,7 @@ class UnknownPropertiesTest extends TestCase
      */
     public function additional_properties_ignored_with_track_flag(): void
     {
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             [],
             ['blim' => 'blam'],
@@ -121,7 +121,7 @@ class UnknownPropertiesTest extends TestCase
     public function cannot_query_unknown_properties_with_ignore_flag(): void
     {
         $unknownProperties = ['blim' => 'blam'];
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             [],
             $unknownProperties,
@@ -140,7 +140,7 @@ class UnknownPropertiesTest extends TestCase
     public function can_query_unknown_properties_with_track_flag(): void
     {
         $unknownProperties = ['blim' => 'blam'];
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             [],
             $unknownProperties,
@@ -158,7 +158,7 @@ class UnknownPropertiesTest extends TestCase
      */
     public function can_query_unknown_property_names_with_track_flag(): void
     {
-        $object = $this->factory->makeWithPropertyTypes(
+        $object = $this->factory->make(
             DataTransferObject::class,
             [],
             ['blim' => 'blam'],

--- a/tests/Unit/ValueProcessingTest.php
+++ b/tests/Unit/ValueProcessingTest.php
@@ -53,7 +53,7 @@ class ValueProcessingTest extends TestCase
      */
     public function process_immutable_throws(): void
     {
-        $propertyType = $this->factory->makePropertyType('', []);
+        $propertyType = $this->factory->makePropertyType('', ['mixed']);
 
         $this->expectException(ImmutableError::class);
 
@@ -66,7 +66,7 @@ class ValueProcessingTest extends TestCase
      */
     public function process_invalid_type_throws(): void
     {
-        $propertyType = $this->factory->makePropertyType('', []);
+        $propertyType = $this->factory->makePropertyType('', ['string']);
 
         $this->expectException(InvalidTypeError::class);
         $this->factory->processValue($propertyType, null, MUTABLE);
@@ -78,8 +78,7 @@ class ValueProcessingTest extends TestCase
      */
     public function process_value_does_not_change_simple_types(): void
     {
-        $propertyType = $this->createMock(PropertyType::class);
-        $propertyType->method('isValidValueForType')->willReturn(true);
+        $propertyType = $this->factory->makePropertyType('', ['mixed']);
 
         $values = [
             'blim',

--- a/tests/Unit/ValueProcessingTest.php
+++ b/tests/Unit/ValueProcessingTest.php
@@ -9,7 +9,6 @@ use Rexlabs\DataTransferObject\DataTransferObject;
 use Rexlabs\DataTransferObject\Exceptions\ImmutableError;
 use Rexlabs\DataTransferObject\Exceptions\InvalidTypeError;
 use Rexlabs\DataTransferObject\Factory;
-use Rexlabs\DataTransferObject\PropertyType;
 use Rexlabs\DataTransferObject\Tests\Feature\Examples\TestingNestableDto;
 
 use const Rexlabs\DataTransferObject\MUTABLE;


### PR DESCRIPTION
DTO creation has gotten messy during changes. 

Refactor DataTransferObject::make to be clear in how it handles:

- defaults
- undefined props
- partials