### PR TITLE
1.0.0-rc-part-9: is defined array objects

### DIFF
--- a/tests/Unit/IssetIsDefinedTest.php
+++ b/tests/Unit/IssetIsDefinedTest.php
@@ -2,6 +2,7 @@
 
 namespace Rexlabs\DataTransferObject\Tests\Unit;
 
+use Rexlabs\DataTransferObject\ClassData;
 use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesTypeError;
 use Rexlabs\DataTransferObject\Tests\Support\TestDataTransferObject;
 use Rexlabs\DataTransferObject\Tests\TestCase;
@@ -95,6 +96,102 @@ class IssetIsDefinedTest extends TestCase
         );
 
         self::assertTrue($object->isDefined('blim.blam.beep'));
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function is_defined_supports_dot_notation_for_nested_arrays(): void
+    {
+        $object = new TestDataTransferObject(
+            ['blim' => $this->factory->makePropertyType('blim', ['mixed'])],
+            [
+                'blim' => new TestDataTransferObject(
+                    ['blam' => $this->factory->makePropertyType('blam', ['array'])],
+                    [
+                        'blam' => [
+                            'beep' => [
+                                'boop' => true,
+                            ],
+                        ],
+                    ],
+                    [],
+                    NONE
+                )
+            ],
+            [],
+            NONE
+        );
+
+        self::assertTrue($object->isDefined('blim.blam.beep.boop'));
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function is_defined_supports_dot_notation_for_nested_objects(): void
+    {
+        $object = new TestDataTransferObject(
+            ['blim' => $this->factory->makePropertyType('blim', ['mixed'])],
+            [
+                'blim' => new TestDataTransferObject(
+                    ['blam' => $this->factory->makePropertyType('blam', ['array'])],
+                    [
+                        'blam' => [
+                            'beep' => (object)[
+                                'boop' => new ClassData('test', '', '', [], NONE)
+                            ],
+                        ],
+                    ],
+                    [],
+                    NONE
+                )
+            ],
+            [],
+            NONE
+        );
+
+        self::assertTrue($object->isDefined('blim.blam.beep.boop'));
+        self::assertTrue($object->isDefined('blim.blam.beep.boop.namespace'));
+        self::assertEquals('test', $object->__get('blim')->__get('blam')['beep']->boop->namespace);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function nested_unknown_properties_show_path(): void
+    {
+        $object = new TestDataTransferObject(
+            ['blim' => $this->factory->makePropertyType('blim', ['mixed'])],
+            [
+                'blim' => new TestDataTransferObject(
+                    ['blam' => $this->factory->makePropertyType('blam', ['mixed'])],
+                    [
+                        'blam' => new TestDataTransferObject(
+                            ['beep' => $this->factory->makePropertyType('beep', ['mixed'])],
+                            ['beep' => true],
+                            [],
+                            NONE
+                        )
+                    ],
+                    [],
+                    NONE
+                )
+            ],
+            [],
+            NONE
+        );
+
+        try {
+            self::assertTrue($object->isDefined('blim.blam.braawwwwwwwwp.beep'));
+            self::fail('Expected have thrown unknown property exception');
+            return;
+        } catch (UnknownPropertiesTypeError $e) {
+            self::assertRegExp('/\\n.*\bblim.blam.braawwwwwwwwp\b$/', $e->getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
Is defined dot '.' notation currently only supports nested DTOs and uses recursion.

- convert recursive method to iterative approach
- add support for ArrayAccess
- add support for objects
- add support for arrays
- show full nested property path for unknown properties on nested DTOs
- add tests for nested types