### PR TITLE
1.0.0-rc-part-10: to array with defaults

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -524,25 +524,37 @@ abstract class DataTransferObject
     {
         return json_encode($this->toArray(), $options, $depth);
     }
-
     /**
      * @return array
      */
     public function toArray(): array
     {
-        return $this->recursiveToArray($this->properties);
+        return $this->recursiveToArray($this->properties, false);
+    }
+
+    /**
+     * @return array
+     */
+    public function toArrayWithDefaults(): array
+    {
+        return $this->recursiveToArray($this->getPropertiesWithDefaults(), true);
     }
 
     /**
      * @param array $data
+     * @param bool $withDefaults
      *
      * @return array
      */
-    private function recursiveToArray(array $data): array
+    private function recursiveToArray(array $data, bool $withDefaults): array
     {
         foreach ($data as $name => $value) {
             if (is_array($value)) {
-                $data[$name] = $this->recursiveToArray($value);
+                $data[$name] = $this->recursiveToArray($value, $withDefaults);
+            } elseif ($value instanceof self) {
+                $data[$name] = $withDefaults
+                    ? $value->toArrayWithDefaults()
+                    : $value->toArray();
             } elseif (method_exists($value, 'toArray')) {
                 $data[$name] = $value->toArray();
             }

--- a/tests/Unit/DefaultValuesTest.php
+++ b/tests/Unit/DefaultValuesTest.php
@@ -93,6 +93,92 @@ class DefaultValuesTest extends TestCase
      *
      * @return void
      */
+    public function defaults_not_set_on_to_array_without_flag_with_partial(): void
+    {
+        $this->factory->setClassMetadata(new DTOMetadata(
+            TestDataTransferObject::class,
+            $this->factory->makePropertyTypes(
+                [
+                    'one' => ['string'],
+                    'two' => ['string'],
+                    'three' => ['string'],
+                    'four' => ['null', 'string'],
+                ],
+                [
+                    'three' => 'default_value',
+                    'four' => '',
+                ]
+            ),
+            NONE
+        ));
+
+        // Missing two parameters
+        $properties = [
+            'one' => 'one',
+            'two' => 'two',
+        ];
+
+        // Missing properties have default values
+        $dto = TestDataTransferObject::make($properties, PARTIAL);
+        $data = $dto->toArray();
+
+        self::assertArrayNotHasKey('three', $data);
+        self::assertArrayNotHasKey('four', $data);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function defaults_set_on_to_array_with_defaults_without_flag_with_partial(): void
+    {
+        $this->factory->setClassMetadata(new DTOMetadata(
+            TestDataTransferObject::class,
+            $this->factory->makePropertyTypes(
+                [
+                    'one' => ['string'],
+                    'two' => ['string'],
+                    'three' => ['string'],
+                    'four' => ['null', 'string'],
+                    'parent' => [TestDataTransferObject::class],
+                ],
+                [
+                    'three' => 'default_value',
+                    'four' => '',
+                ]
+            ),
+            NONE
+        ));
+
+        // Missing two parameters
+        $properties = [
+            'one' => 'one',
+            'two' => 'two',
+            'parent' => [
+                'one' => 'one',
+                'two' => 'two',
+            ]
+        ];
+
+        // Missing properties have default values
+        $dto = TestDataTransferObject::make($properties, PARTIAL);
+        $data = $dto->toArrayWithDefaults();
+
+        self::assertArrayHasKey('three', $data);
+        self::assertArrayHasKey('four', $data);
+        self::assertArrayHasKey('parent', $data);
+
+        $parent = $data['parent'];
+        self::assertArrayHasKey('three', $parent);
+        self::assertArrayHasKey('four', $parent);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
     public function access_to_undefined_on_partial_throws(): void
     {
         $this->factory->setClassMetadata(new DTOMetadata(


### PR DESCRIPTION
Allow for serializing with defaults for missing props. Recursively set defaults on missing properties down through nested DTOs.

- Added new method `toArrayWithDefaults`