### PR TITLE
1.0.0-rc-part-12: property ref

### DIFF
--- a/src/ClassData/DTOMetadata.php
+++ b/src/ClassData/DTOMetadata.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rexlabs\DataTransferObject\ClassData;
 
 use Rexlabs\DataTransferObject\Type\PropertyType;
+use Rexlabs\DataTransferObject\Type\PropertyReference;
 
 /**
  * Class DTOMetadata
@@ -19,6 +20,9 @@ class DTOMetadata
     /** @var PropertyType[] */
     public $propertyTypes;
 
+    /** @var PropertyReference */
+    public $ref;
+
     /** @var int */
     public $baseFlags;
 
@@ -27,12 +31,18 @@ class DTOMetadata
      *
      * @param string $class
      * @param PropertyType[] $propertyTypes
+     * @param PropertyReference $ref
      * @param int $baseFlags
      */
-    public function __construct(string $class, array $propertyTypes, int $baseFlags)
-    {
+    public function __construct(
+        string $class,
+        array $propertyTypes,
+        PropertyReference $ref,
+        int $baseFlags
+    ) {
         $this->class = $class;
         $this->propertyTypes = $propertyTypes;
+        $this->ref = $ref;
         $this->baseFlags = $baseFlags;
     }
 }

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -13,6 +13,8 @@ use Rexlabs\DataTransferObject\Exceptions\UndefinedPropertiesTypeError;
 use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesTypeError;
 use Rexlabs\DataTransferObject\Factory\Factory;
 use Rexlabs\DataTransferObject\Factory\FactoryContract;
+use Rexlabs\DataTransferObject\Type\IsDefinedReference;
+use Rexlabs\DataTransferObject\Type\PropertyReference;
 use Rexlabs\DataTransferObject\Type\PropertyType;
 
 abstract class DataTransferObject
@@ -40,6 +42,9 @@ abstract class DataTransferObject
      */
     private $unknownProperties;
 
+    /** @var IsDefinedReference|static */
+    private $refIsDefined;
+
     /**
      * No validation or checking is done in constructor
      * Use `MyTransferObject::make($data)` instead
@@ -61,6 +66,7 @@ abstract class DataTransferObject
         $this->properties = $properties;
         $this->flags = $flags;
         $this->unknownProperties = $unknownProperties;
+        $this->refIsDefined = new IsDefinedReference($this);
     }
 
     /**
@@ -81,6 +87,28 @@ abstract class DataTransferObject
     protected static function getCasts(): array
     {
         return [];
+    }
+
+    /**
+     * Get a property reference for code completion / refactoring on property names
+     * References will return their string name
+     *
+     * @return PropertyReference|static Magic mixin for property name code completion / refactoring
+     */
+    public static function ref(): PropertyReference
+    {
+        return self::getFactory()->getClassMetadata(static::class)->ref;
+    }
+
+    /**
+     * Get a reference for defined properties
+     * References will return bool isDefined
+     *
+     * @return IsDefinedReference|static Magic mixin for property name code completion / refactoring
+     */
+    public function refIsDefined(): IsDefinedReference
+    {
+        return $this->refIsDefined;
     }
 
     /**

--- a/src/Factory/Factory.php
+++ b/src/Factory/Factory.php
@@ -13,6 +13,8 @@ use Rexlabs\DataTransferObject\Type\Casts\DataTransferObjectPropertyCast;
 use Rexlabs\DataTransferObject\Type\PropertyCast;
 use Rexlabs\DataTransferObject\Type\PropertyType;
 
+use Rexlabs\DataTransferObject\Type\PropertyReference;
+
 use function array_key_exists;
 use function sprintf;
 
@@ -124,10 +126,14 @@ class Factory implements FactoryContract
                 is_array($classPropertyCasts) ? $classPropertyCasts : [$classPropertyCasts]
             );
         }
+        $names = array_keys($propertyTypesMap);
+
+        $ref =new PropertyReference(static::class, array_combine($names, $names));
 
         $this->classMetadata[$class] = new DTOMetadata(
             $class,
             $propertyTypes,
+            $ref,
             $flags
         );
 

--- a/src/Type/IsDefinedReference.php
+++ b/src/Type/IsDefinedReference.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rexlabs\DataTransferObject\Type;
+
+use LogicException;
+use Rexlabs\DataTransferObject\DataTransferObject;
+
+class IsDefinedReference
+{
+    /** @var DataTransferObject */
+    private $dto;
+
+    /**
+     * IsDefinedReference constructor.
+     *
+     * @param DataTransferObject $dto
+     */
+    public function __construct(DataTransferObject $dto)
+    {
+        $this->dto = $dto;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function __get(string $name): bool
+    {
+        return $this->dto->isDefined($name);
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $value
+     *
+     * @return void
+     * @deprecated Not supported
+     */
+    public function __set(string $name, $value): void
+    {
+        throw new LogicException('Not supported');
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return void
+     * @deprecated Not supported
+     */
+    public function __isset(string $name): void
+    {
+        throw new LogicException('Not supported');
+    }
+}

--- a/src/Type/PropertyReference.php
+++ b/src/Type/PropertyReference.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Rexlabs\DataTransferObject\Type;
+
+use LogicException;
+use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesTypeError;
+
+/**
+ * Class PropertyReference
+ *
+ * @package Rexlabs\DataTransferObject\Type
+ */
+class PropertyReference
+{
+    /** @var string */
+    private $class;
+
+    /** @var string[] */
+    private $names;
+
+    /**
+     * Ref constructor.
+     *
+     * @param string $class
+     * @param bool[] $names ['name' => true]
+     */
+    public function __construct(string $class, array $names)
+    {
+        $this->class = $class;
+        $this->names = $names;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    public function __get(string $name): string
+    {
+        if (!($this->names[$name] ?? false)) {
+            throw new UnknownPropertiesTypeError($this->class, [$name]);
+        }
+
+        return $name;
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $value
+     *
+     * @return void
+     * @deprecated Not supported
+     */
+    public function __set(string $name, $value): void
+    {
+        throw new LogicException('Not supported');
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return void
+     * @deprecated Not supported
+     */
+    public function __isset(string $name): void
+    {
+        throw new LogicException('Not supported');
+    }
+}

--- a/tests/Feature/ReferenceTest.php
+++ b/tests/Feature/ReferenceTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Rexlabs\DataTransferObject\Tests\Feature;
+
+use Faker\Factory as Faker;
+use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesTypeError;
+use Rexlabs\DataTransferObject\Tests\Support\ExampleDataTransferObject;
+use Rexlabs\DataTransferObject\Tests\TestCase;
+
+use const Rexlabs\DataTransferObject\PARTIAL;
+
+class ReferenceTest extends TestCase
+{
+    /**
+     * @test
+     * @return void
+     */
+    public function static_ref_returns_valid_strings(): void
+    {
+        $ref = ExampleDataTransferObject::ref();
+
+        $firstNamePropertyName = $ref->first_name;
+        $siblingsPropertyName = $ref->siblings;
+
+        self::assertIsString($firstNamePropertyName);
+        self::assertEquals('first_name', $firstNamePropertyName);
+        self::assertIsString($siblingsPropertyName);
+        self::assertEquals('siblings', $siblingsPropertyName);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function instance_ref_returns_valid_strings(): void
+    {
+        $dto = ExampleDataTransferObject::make([], PARTIAL);
+        $ref = $dto::ref();
+
+        $firstNamePropertyName = $ref->first_name;
+        $siblingsPropertyName = $ref->siblings;
+
+        self::assertIsString($firstNamePropertyName);
+        self::assertEquals('first_name', $firstNamePropertyName);
+        self::assertIsString($siblingsPropertyName);
+        self::assertEquals('siblings', $siblingsPropertyName);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function is_defined_ref_throws_unknown(): void
+    {
+        $dto = ExampleDataTransferObject::make([], PARTIAL);
+
+        $isDefined = $dto->refIsDefined();
+
+        $this->expectException(UnknownPropertiesTypeError::class);
+        $isDefined->__get('not a real property name');
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function is_defined_returns_valid_bool(): void
+    {
+        $faker = Faker::create();
+
+        $dto = ExampleDataTransferObject::make([
+            'first_name' => $faker->firstName,
+            'last_name' => $faker->lastName,
+        ], PARTIAL);
+
+        $isDefined = $dto->refIsDefined();
+        $firstNameDefined = $isDefined->first_name;
+
+        self::assertIsBool($firstNameDefined);
+        self::assertTrue($firstNameDefined);
+
+        self::assertTrue($isDefined->last_name);
+        self::assertFalse($isDefined->id);
+    }
+}

--- a/tests/Unit/IssetIsDefinedTest.php
+++ b/tests/Unit/IssetIsDefinedTest.php
@@ -295,14 +295,13 @@ class IssetIsDefinedTest extends TestCase
      */
     public function unknown_property_is_defined_throws(): void
     {
-        $this->expectException(UnknownPropertiesTypeError::class);
-
-        $propertyTypes = $this->factory->setClassMetadata(
-            TestDataTransferObject::class,
-            [
-                'blim' => ['null'],
-            ]
-        )
+        $propertyTypes = $this->factory
+            ->setClassMetadata(
+                TestDataTransferObject::class,
+                [
+                    'blim' => ['null'],
+                ]
+            )
             ->propertyTypes;
 
         $object = new TestDataTransferObject(
@@ -312,6 +311,7 @@ class IssetIsDefinedTest extends TestCase
             NONE
         );
 
+        $this->expectException(UnknownPropertiesTypeError::class);
         self::assertFalse($object->isDefined('blam'));
     }
 }


### PR DESCRIPTION
### Issue

When creating / checking DTOs there are still too many string literals for property names used. These cannot be refactored and create overhead / uncertainty.

### Solution

IsDefinedReference can return a class of type static that knows which props are defined.

```php
$isDefined = $made->refIsDefined();
if ($isDefined->name) {
   // do things 
}
```

Pros:

- refactoring will update references to `name` automatically
- spelling mistakes will be picked up by ide

Cons:

- hacky because IsDefined is not really the same type and nested props would fail.

In assemblers frequenltly we create an array of props to check.

```php
$def = Dto::ref();
$allowList= [
    $def->name,
    $def->email,
];
```

### Working Example

![image](https://user-images.githubusercontent.com/644146/94015111-c574d200-fdef-11ea-8642-0c8cbaaee26f.png)

- Phpstorm shows `$ref` as type `PropertyReference` and `ExampleDataTransferObject`
- properties are highlighted correctly

![image](https://user-images.githubusercontent.com/644146/94015526-56e44400-fdf0-11ea-908d-b7921993696b.png)

- Phpstorm shows `$siblingsPropertyName` as type `ExampleDataTransferObject[]` and `string`  (string for the property name from the magic __get() mixin)

![image](https://user-images.githubusercontent.com/644146/94015714-9579fe80-fdf0-11ea-930c-1db65adab7db.png)
- Phpstorm refactor change property name

![image](https://user-images.githubusercontent.com/644146/94015792-ac205580-fdf0-11ea-987f-d40ef9005f55.png)

- All references updated automatically
