### PR TITLE
Remake method fix + method signature updates

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -308,7 +308,7 @@ abstract class DataTransferObject
     public function remakeExcept(
         array $exceptPropertyNames,
         array $override,
-        int $flags = NONE
+        int $flags = null
     ): self {
         $this->assertKnownPropertyNames($exceptPropertyNames);
 
@@ -317,7 +317,7 @@ abstract class DataTransferObject
             array_flip($exceptPropertyNames)
         );
 
-        return self::make(array_merge($properties, $override), $flags);
+        return self::make(array_merge($properties, $override), $flags ?? $this->flags);
     }
 
     /**
@@ -471,6 +471,14 @@ abstract class DataTransferObject
     public function isMutable(): bool
     {
         return (bool)($this->flags & MUTABLE);
+    }
+
+    /**
+     * @return int
+     */
+    public function getFlags(): int
+    {
+        return $this->flags;
     }
 
     /**

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -282,7 +282,7 @@ abstract class DataTransferObject
      */
     public function remakeOnly(
         array $onlyPropertyNames,
-        array $override,
+        array $override = [],
         $flags = null
     ): self {
         $this->assertKnownPropertyNames($onlyPropertyNames);
@@ -307,7 +307,7 @@ abstract class DataTransferObject
      */
     public function remakeExcept(
         array $exceptPropertyNames,
-        array $override,
+        array $override = [],
         int $flags = null
     ): self {
         $this->assertKnownPropertyNames($exceptPropertyNames);


### PR DESCRIPTION
* Fixes flag bug in remakeExcept (existing flags weren't being used)
* Adds some basic tests for remake + flags
* Makes override optional for remakeExcept + remakeOnly given common usage would be `$dto->remakeExcept(['xyz'])` - having to provide a second empty array in this context e.g. `$dto->remakeExcept(['xyz'], [])` isn't ideal.
* Exposes getFlags method for testing but also because knowing what flags the DTO has been initialised with could be useful.