### PR TITLE
feat: Add isUndefined, assertUndefined, assertOnlyDefined

### DIFF
--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -10,6 +10,7 @@ use LogicException;
 use Rexlabs\DataTransferObject\Exceptions\ImmutableTypeError;
 use Rexlabs\DataTransferObject\Exceptions\InvalidTypeError;
 use Rexlabs\DataTransferObject\Exceptions\UndefinedPropertiesTypeError;
+use Rexlabs\DataTransferObject\Exceptions\UnexpectedlyDefinedPropertiesTypeError;
 use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesTypeError;
 use Rexlabs\DataTransferObject\Factory\Factory;
 use Rexlabs\DataTransferObject\Factory\FactoryContract;
@@ -466,6 +467,18 @@ abstract class DataTransferObject
     }
 
     /**
+     * Inverse behaviour of isDefined
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function isUndefined(string $name): bool
+    {
+        return !$this->isDefined($name);
+    }
+
+    /**
      * @return bool
      */
     public function isMutable(): bool
@@ -540,12 +553,33 @@ abstract class DataTransferObject
         $undefined = array_filter(
             (array)$propertyNames,
             function (string $propertyName) {
-                return !$this->isDefined($propertyName);
+                return $this->isUndefined($propertyName);
             }
         );
 
         if (!empty($undefined)) {
             throw new UndefinedPropertiesTypeError(static::class, $undefined);
+        }
+    }
+
+    /**
+     * @param string|array $propertyNames
+     *
+     * @return void
+     */
+    public function assertUndefined($propertyNames): void
+    {
+        $this->assertKnownPropertyNames($propertyNames);
+
+        $defined = array_filter(
+            (array)$propertyNames,
+            function (string $propertyName) {
+                return $this->isDefined($propertyName);
+            }
+        );
+
+        if (!empty($defined)) {
+            throw new UnexpectedlyDefinedPropertiesTypeError(static::class, $defined);
         }
     }
 

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -10,7 +10,7 @@ use LogicException;
 use Rexlabs\DataTransferObject\Exceptions\ImmutableTypeError;
 use Rexlabs\DataTransferObject\Exceptions\InvalidTypeError;
 use Rexlabs\DataTransferObject\Exceptions\UndefinedPropertiesTypeError;
-use Rexlabs\DataTransferObject\Exceptions\UnexpectedlyDefinedPropertiesTypeError;
+use Rexlabs\DataTransferObject\Exceptions\ValidButUnexpectedPropertiesDefinedTypeError;
 use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesTypeError;
 use Rexlabs\DataTransferObject\Factory\Factory;
 use Rexlabs\DataTransferObject\Factory\FactoryContract;
@@ -563,6 +563,24 @@ abstract class DataTransferObject
     }
 
     /**
+     * Ensure only the given list of properties is defined (any properties defined and not in the list will throw)
+     *
+     * @param string|array $propertyNames
+     * @return void
+     */
+    public function assertOnlyDefined($propertyNames): void
+    {
+        $this->assertDefined($propertyNames);
+
+        $propertyNames = (array)$propertyNames;
+        $unexpectedDefinedPropertyNames = array_diff($this->getDefinedPropertyNames(), $propertyNames);
+
+        if (!empty($unexpectedDefinedPropertyNames)) {
+            throw new ValidButUnexpectedPropertiesDefinedTypeError(static::class, $unexpectedDefinedPropertyNames);
+        }
+    }
+
+    /**
      * @param string|array $propertyNames
      *
      * @return void
@@ -579,7 +597,7 @@ abstract class DataTransferObject
         );
 
         if (!empty($defined)) {
-            throw new UnexpectedlyDefinedPropertiesTypeError(static::class, $defined);
+            throw new ValidButUnexpectedPropertiesDefinedTypeError(static::class, $defined);
         }
     }
 

--- a/src/Exceptions/UnexpectedlyDefinedPropertiesTypeError.php
+++ b/src/Exceptions/UnexpectedlyDefinedPropertiesTypeError.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rexlabs\DataTransferObject\Exceptions;
+
+use Throwable;
+
+/**
+ * Class UnexpectedlyDefinedPropertiesTypeError
+ *
+ * @package Rexlabs\DataTransferObject\Exceptions
+ */
+class UnexpectedlyDefinedPropertiesTypeError extends DataTransferObjectTypeError
+{
+    /** @var string */
+    private $class;
+
+    /** @var string[] */
+    private $propertyNames;
+
+    /**
+     * UndefinedPropertiesError constructor.
+     *
+     * @param string $class
+     * @param array $propertyNames
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        string $class,
+        array $propertyNames,
+        int $code = 0,
+        Throwable $previous = null
+    ) {
+        parent::__construct(
+            self::buildMessage($class, $propertyNames),
+            $code,
+            $previous
+        );
+        $this->class = $class;
+        $this->propertyNames = $propertyNames;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return array
+     */
+    public function getNestedPropertyNames(string $name): array
+    {
+        $nestedPropertyNames = [];
+        foreach ($this->propertyNames as $propertyName) {
+            $nestedPropertyNames[] = $name . '.' . $propertyName;
+        }
+        return $nestedPropertyNames;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPropertyNames(): array
+    {
+        return $this->propertyNames;
+    }
+
+    /**
+     * @param string $class
+     * @param array $propertyNames
+     *
+     * @return string
+     */
+    private static function buildMessage(string $class, array $propertyNames): string
+    {
+        $classParts = explode('\\', $class);
+        $shortClass = end($classParts);
+        $pluralProperty = count($propertyNames) === 1
+            ? 'Property'
+            : 'Properties';
+        $properties = array_map(
+            function ($propertyName): string {
+                return ' - ' . $propertyName;
+            },
+            $propertyNames
+        );
+
+        return sprintf(
+            "Unexpectedly defined %s for %s\n%s",
+            $pluralProperty,
+            $shortClass,
+            implode("\n", $properties)
+        );
+    }
+}

--- a/src/Exceptions/ValidButUnexpectedPropertiesDefinedTypeError.php
+++ b/src/Exceptions/ValidButUnexpectedPropertiesDefinedTypeError.php
@@ -11,7 +11,7 @@ use Throwable;
  *
  * @package Rexlabs\DataTransferObject\Exceptions
  */
-class UnexpectedlyDefinedPropertiesTypeError extends DataTransferObjectTypeError
+class ValidButUnexpectedPropertiesDefinedTypeError extends DataTransferObjectTypeError
 {
     /** @var string */
     private $class;
@@ -93,7 +93,7 @@ class UnexpectedlyDefinedPropertiesTypeError extends DataTransferObjectTypeError
         );
 
         return sprintf(
-            "Unexpectedly defined %s for %s\n%s",
+            "Valid, but unexpected %s defined for %s\n%s",
             $pluralProperty,
             $shortClass,
             implode("\n", $properties)

--- a/tests/Unit/DefinedAssertionTest.php
+++ b/tests/Unit/DefinedAssertionTest.php
@@ -10,7 +10,7 @@ use Rexlabs\DataTransferObject\Tests\TestCase;
 
 use const Rexlabs\DataTransferObject\PARTIAL;
 
-class AssertionTest extends TestCase
+class DefinedAssertionTest extends TestCase
 {
     /**
      * @test

--- a/tests/Unit/IssetIsDefinedTest.php
+++ b/tests/Unit/IssetIsDefinedTest.php
@@ -92,6 +92,8 @@ class IssetIsDefinedTest extends TestCase
 
         self::assertTrue($object->isDefined('blim'));
         self::assertTrue($object->isDefined('blam'));
+        self::assertFalse($object->isUndefined('blim'));
+        self::assertFalse($object->isUndefined('blam'));
     }
 
     /**
@@ -122,9 +124,11 @@ class IssetIsDefinedTest extends TestCase
         );
 
         self::assertTrue($dto->isDefined('parent.parent.parent.flim'));
+        self::assertFalse($dto->isUndefined('parent.parent.parent.flim'));
         self::assertInstanceOf(TestDataTransferObject::class, $dto->__get('parent')->__get('parent')->__get('parent'));
         self::assertIsString($dto->__get('parent')->__get('parent')->__get('parent')->__get('flim'));
         self::assertFalse($dto->isDefined('parent.parent.parent.parent'));
+        self::assertTrue($dto->isUndefined('parent.parent.parent.parent'));
     }
 
     /**
@@ -153,9 +157,11 @@ class IssetIsDefinedTest extends TestCase
         );
 
         self::assertTrue($dto->isDefined('parent.parent.parent.flim'));
+        self::assertFalse($dto->isUndefined('parent.parent.parent.flim'));
         self::assertIsArray($dto->__get('parent')['parent']['parent']);
         self::assertIsString($dto->__get('parent')['parent']['parent']['flim']);
         self::assertFalse($dto->isDefined('parent.parent.parent.parent'));
+        self::assertTrue($dto->isUndefined('parent.parent.parent.parent'));
     }
 
     /**
@@ -184,9 +190,11 @@ class IssetIsDefinedTest extends TestCase
         );
 
         self::assertTrue($dto->isDefined('parent.parent.parent.flim'));
+        self::assertFalse($dto->isUndefined('parent.parent.parent.flim'));
         self::assertIsObject($dto->__get('parent')->parent->parent);
         self::assertIsString($dto->__get('parent')->parent->parent->flim);
         self::assertFalse($dto->isDefined('parent.parent.parent.parent'));
+        self::assertTrue($dto->isUndefined('parent.parent.parent.parent'));
     }
 
     /**
@@ -221,9 +229,11 @@ class IssetIsDefinedTest extends TestCase
         );
 
         self::assertTrue($dto->isDefined('parent.parent.parent.flim'));
+        self::assertFalse($dto->isUndefined('parent.parent.parent.flim'));
         self::assertIsObject($dto->__get('parent')['parent']['parent']);
         self::assertIsString($dto->__get('parent')['parent']['parent']['flim']);
         self::assertFalse($dto->isDefined('parent.parent.parent.parent'));
+        self::assertTrue($dto->isUndefined('parent.parent.parent.parent'));
     }
 
     /**
@@ -287,6 +297,7 @@ class IssetIsDefinedTest extends TestCase
         );
 
         self::assertFalse($object->isDefined('blim'));
+        self::assertTrue($object->isUndefined('blim'));
     }
 
     /**

--- a/tests/Unit/OnlyDefinedAssertionTest.php
+++ b/tests/Unit/OnlyDefinedAssertionTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Rexlabs\DataTransferObject\Tests\Unit;
+
+use Faker\Factory;
+use Rexlabs\DataTransferObject\Exceptions\UndefinedPropertiesTypeError;
+use Rexlabs\DataTransferObject\Exceptions\ValidButUnexpectedPropertiesDefinedTypeError;
+use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesTypeError;
+use Rexlabs\DataTransferObject\Tests\Support\TestDataTransferObject;
+use Rexlabs\DataTransferObject\Tests\TestCase;
+
+use const Rexlabs\DataTransferObject\PARTIAL;
+
+class OnlyDefinedAssertionTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function exactly_defined_properties_passed_assertion(): void
+    {
+        $this->factory->setClassMetadata(
+            TestDataTransferObject::class,
+            [
+                'id' => ['string'],
+                'first_name' => ['string'],
+                'last_name' => ['null', 'string'],
+            ]
+        );
+
+        $faker = Factory::create();
+
+        $dto = TestDataTransferObject::make(
+            [
+                'id' => $faker->uuid,
+                'last_name' => $faker->lastName,
+            ],
+            PARTIAL
+        );
+
+        $dto->assertOnlyDefined(['id', 'last_name']);
+
+        // No exception was thrown
+        self::assertTrue(true);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function unexpectedly_defined_properties_fail_assertion(): void
+    {
+        $this->factory->setClassMetadata(
+            TestDataTransferObject::class,
+            [
+                'id' => ['string'],
+                'first_name' => ['string'],
+                'last_name' => ['null', 'string'],
+            ]
+        );
+
+        $faker = Factory::create();
+
+        $dto = TestDataTransferObject::make(
+            [
+                'id' => $faker->uuid,
+                'first_name' => $faker->firstName,
+                'last_name' => $faker->lastName,
+            ],
+            PARTIAL
+        );
+
+        // We don't expect id to be defined
+        $this->expectException(ValidButUnexpectedPropertiesDefinedTypeError::class);
+        $dto->assertOnlyDefined(['id', 'last_name']);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function can_test_single_string_prop(): void
+    {
+        $this->factory->setClassMetadata(
+            TestDataTransferObject::class,
+            [
+                'id' => ['string'],
+                'first_name' => ['string'],
+                'last_name' => ['null', 'string'],
+            ]
+        );
+
+        $faker = Factory::create();
+        $dto = TestDataTransferObject::make(
+            [
+                'id' => $faker->uuid,
+            ],
+            PARTIAL
+        );
+
+        $dto->assertOnlyDefined('id');
+
+        // No exception was thrown
+        self::assertTrue(true);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function undefined_properties_fail_assertion(): void
+    {
+        $this->factory->setClassMetadata(
+            TestDataTransferObject::class,
+            [
+                'id' => ['string'],
+                'first_name' => ['string'],
+                'last_name' => ['null', 'string'],
+            ]
+        );
+
+        $faker = Factory::create();
+        $dto = TestDataTransferObject::make(
+            [
+                'id' => $faker->uuid,
+                'first_name' => $faker->firstName,
+            ],
+            PARTIAL
+        );
+
+        $this->expectException(UndefinedPropertiesTypeError::class);
+
+        $dto->assertOnlyDefined(['last_name']);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function unknown_properties_fail_before_assertion(): void
+    {
+        $this->factory->setClassMetadata(
+            TestDataTransferObject::class,
+            [
+                'id' => ['string'],
+                'first_name' => ['string'],
+                'last_name' => ['null', 'string'],
+            ]
+        );
+
+        $faker = Factory::create();
+        $dto = TestDataTransferObject::make(
+            [
+                'id' => $faker->uuid,
+                'first_name' => $faker->firstName,
+            ],
+            PARTIAL
+        );
+
+        $this->expectException(UnknownPropertiesTypeError::class);
+
+        $dto->assertOnlyDefined(['flim']);
+    }
+}

--- a/tests/Unit/UndefinedAssertionTest.php
+++ b/tests/Unit/UndefinedAssertionTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Rexlabs\DataTransferObject\Tests\Unit;
+
+use Faker\Factory;
+use Rexlabs\DataTransferObject\Exceptions\UndefinedPropertiesTypeError;
+use Rexlabs\DataTransferObject\Exceptions\UnknownPropertiesTypeError;
+use Rexlabs\DataTransferObject\Tests\Support\TestDataTransferObject;
+use Rexlabs\DataTransferObject\Tests\TestCase;
+
+use const Rexlabs\DataTransferObject\PARTIAL;
+
+class UndefinedAssertionTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function undefined_properties_passed_assertion(): void
+    {
+        $this->factory->setClassMetadata(
+            TestDataTransferObject::class,
+            [
+                'id' => ['string'],
+                'first_name' => ['string'],
+                'last_name' => ['null', 'string'],
+            ]
+        );
+
+        $faker = Factory::create();
+
+        $dto = TestDataTransferObject::make(
+            [
+                'first_name' => $faker->firstName,
+            ],
+            PARTIAL
+        );
+
+        $dto->assertUndefined(['id', 'last_name']);
+
+        // No exception was thrown
+        self::assertTrue(true);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function can_test_single_string_prop(): void
+    {
+        $this->factory->setClassMetadata(
+            TestDataTransferObject::class,
+            [
+                'id' => ['string'],
+                'first_name' => ['string'],
+                'last_name' => ['null', 'string'],
+            ]
+        );
+
+        $faker = Factory::create();
+        $dto = TestDataTransferObject::make(
+            [
+                'first_name' => $faker->firstName,
+            ],
+            PARTIAL
+        );
+
+        $dto->assertUndefined('id');
+
+        // No exception was thrown
+        self::assertTrue(true);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function undefined_properties_fail_assertion(): void
+    {
+        $this->factory->setClassMetadata(
+            TestDataTransferObject::class,
+            [
+                'id' => ['string'],
+                'first_name' => ['string'],
+                'last_name' => ['null', 'string'],
+            ]
+        );
+
+        $faker = Factory::create();
+        $dto = TestDataTransferObject::make(
+            [
+                'id' => $faker->uuid,
+                'first_name' => $faker->firstName,
+            ],
+            PARTIAL
+        );
+
+        $this->expectException(UndefinedPropertiesTypeError::class);
+
+        $dto->assertDefined(['last_name']);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function unknown_properties_fail_before_assertion(): void
+    {
+        $this->factory->setClassMetadata(
+            TestDataTransferObject::class,
+            [
+                'id' => ['string'],
+                'first_name' => ['string'],
+                'last_name' => ['null', 'string'],
+            ]
+        );
+
+        $faker = Factory::create();
+        $dto = TestDataTransferObject::make(
+            [
+                'id' => $faker->uuid,
+                'first_name' => $faker->firstName,
+            ],
+            PARTIAL
+        );
+
+        $this->expectException(UnknownPropertiesTypeError::class);
+
+        $dto->assertUndefined(['flim']);
+    }
+}


### PR DESCRIPTION
## Description

Introduces `isUndefined` and `assertUndefined` and `assertOnlyDefined` checks as inverse functions of the existing isDefined / assertDefined checks.

## Motivation and context

For isUndefined -> `$data->isUndefined('name')` reads more cleanly / naturally than `!$data->isDefined('name')` or `$data->isDefined('name') === false`.

For `$data->assertUndefined` and `$data->assertOnlyDefined` the main use case for this is when partial objects are expected by some functions (e.g. a create function can accept all attributes but an update function can only accept 2-3 attributes of the same object). Although technically all attributes are valid, we don't really want to check if values that weren't meant to change have been changed - that's the main use case for this.

I realise you have the option of creating additional object types and that would help catch any issues before run time but our utils for object extension and composition etc. aren't currently great. Even if we had those bits of functionality available, i'd still argue these utils would still be relevant and helpful in some cases given that we embrace the concept of `PARTIAL` objects.

## How has this been tested?

Existing tests have been updated

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ ] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
