### PR TITLE
Fix cast nullable dto

### DIFF
--- a/src/Type/Casts/DataTransferObjectPropertyCast.php
+++ b/src/Type/Casts/DataTransferObjectPropertyCast.php
@@ -72,7 +72,7 @@ class DataTransferObjectPropertyCast implements PropertyCast
      *
      * @return mixed
      */
-    public function toData(string $name, $property, int $flags = NONE): array
+    public function toData(string $name, $property, int $flags = NONE): ?array
     {
         if (!$property instanceof DataTransferObject) {
             return $property;

--- a/tests/Unit/CastTest.php
+++ b/tests/Unit/CastTest.php
@@ -593,4 +593,63 @@ class CastTest extends TestCase
 
         self::assertEquals($expected, $dto->toArray());
     }
+
+        /**
+     * @test
+     * @return void
+     */
+    public function can_cast_a_null_nullable_dto(): void
+    {
+        $this->factory->setClassMetadata(
+            TestDataTransferObject2::class,
+            ['name' => ['string']]
+        );
+
+        $this->factory->setClassMetadata(
+            TestDataTransferObject::class,
+            ['user' => ['null', TestDataTransferObject2::class]]
+        );
+
+        $dto = TestDataTransferObject::make([
+            'user' => null,
+        ]);
+
+        $expected = [
+            'user' => null
+        ];
+
+        self::assertEquals($expected, $dto->toArray());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function can_cast_a_not_null_nullable_dto(): void
+    {
+        $this->factory->setClassMetadata(
+            TestDataTransferObject2::class,
+            ['name' => ['string']]
+        );
+
+        $this->factory->setClassMetadata(
+            TestDataTransferObject::class,
+            ['user' => ['null', TestDataTransferObject2::class]]
+        );
+
+        $faker = Faker::create();
+        $name1 = $faker->name;
+
+        $dto = TestDataTransferObject::make([
+            'user' => TestDataTransferObject2::make(['name' => $name1]),
+        ]);
+
+        $expected = [
+            'user' => [
+                'name' => $name1
+            ]
+        ];
+
+        self::assertEquals($expected, $dto->toArray());
+    }
 }


### PR DESCRIPTION
## Description

The PR fixes a small issue casting a nullable DTO.

## Motivation and context

When having for example `* @property null|UserDto $assignee`, using the method `toArray()` or `toArrayWithDefaults()` will give the following error: 
```
Return value of Rexlabs\DataTransferObject\Type\Casts\DataTransferObjectPropertyCast::toData() must be of the type array, null returned
```

## How has this been tested?

I added two tests to `tests/Unit/CastTest.php`. The first, test casting a nullable DTO with a null value. The second, test the same scenario with a non-null value.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.
