### PR TITLE
add getKeys function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 phpcs.xml
 phpunit.xml
 .phpunit.result.cache
+.idea

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -505,6 +505,17 @@ abstract class DataTransferObject
     /**
      * @return array
      */
+    public static function getKeys(): array
+    {
+        $factory = self::getFactory();
+        $meta = $factory->getClassMetadata(static::class);
+        $propertyTypes = $meta->propertyTypes;
+        return array_values(array_keys($propertyTypes));
+    }
+
+    /**
+     * @return array
+     */
     public function getPropertiesWithDefaults(): array
     {
         // Get defaults for undefined properties

--- a/tests/Unit/DataTransferObjectTest.php
+++ b/tests/Unit/DataTransferObjectTest.php
@@ -183,4 +183,20 @@ class DataTransferObjectTest extends TestCase
 
         self::assertEquals($expected, $parent->toArray());
     }
+
+    /**
+     * @test
+     */
+    public function can_get_dto_keys(): void
+    {
+        $this->factory->setClassMetadata(
+            TestDataTransferObject::class,
+            [
+                'one' => ['string'],
+            ]
+        );
+
+
+        self::assertEquals(['one'], TestDataTransferObject::getKeys());
+    }
 }


### PR DESCRIPTION
## Description

Add a getKeys() function to get the keys of a DTO before initialisation. This is useful if you want to map an object onto the DTO.

## How has this been tested?

Added a simple unit test

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
