### PR TITLE
Allow callable to be passed to make method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ $rawData = [
 $kirk = UserDto::make($rawData);
 ```
 
+Alternatively you may use a callable/closure to make a dto. Note the following example is php8.1+ however any callable
+syntax will work in older versions.
+```php
+$dto = UserDto::make(fn ($ref) => [
+    $ref->first_name => 'James',
+    $ref->last_name => 'Kirk',
+    $ref->email => 'jim@starfleet.ufp'
+]);
+```
+
 ## Guide
 
 Data transfer objects are useful in many contexts and have additional features for convenience and refactoring.

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -133,8 +133,7 @@ abstract class DataTransferObject
     {
         // Support callable alternative syntax
         if (is_callable($parameters)) {
-            $array = $parameters(static::ref());
-            return static::make($array, $flags);
+            $parameters = $parameters(static::ref());
         }
 
         assert(

--- a/src/DataTransferObject.php
+++ b/src/DataTransferObject.php
@@ -124,13 +124,24 @@ abstract class DataTransferObject
      *  - throw if types are invalid
      *  - adapt exceptions thrown from nested properties to show full path
      *
-     * @param array $parameters
+     * @param array|callable(static $ref): array $parameters
      * @param int $flags
      *
      * @return static
      */
-    public static function make(array $parameters, int $flags = NONE): self
+    public static function make($parameters, int $flags = NONE): self
     {
+        // Support callable alternative syntax
+        if (is_callable($parameters)) {
+            $array = $parameters(static::ref());
+            return static::make($array, $flags);
+        }
+
+        assert(
+            is_array($parameters),
+            'argument $parameters must be an array or callable'
+        );
+
         $factory = self::getFactory();
         $meta = $factory->getClassMetadata(static::class);
         $propertyTypes = $meta->propertyTypes;
@@ -483,7 +494,7 @@ abstract class DataTransferObject
      */
     public function isMutable(): bool
     {
-        return (bool)($this->flags & MUTABLE);
+        return (bool) ($this->flags & MUTABLE);
     }
 
     /**
@@ -559,7 +570,7 @@ abstract class DataTransferObject
         $this->assertKnownPropertyNames($propertyNames);
 
         $undefined = array_filter(
-            (array)$propertyNames,
+            (array) $propertyNames,
             function (string $propertyName) {
                 return $this->isUndefined($propertyName);
             }
@@ -580,7 +591,7 @@ abstract class DataTransferObject
     {
         $this->assertDefined($propertyNames);
 
-        $propertyNames = (array)$propertyNames;
+        $propertyNames = (array) $propertyNames;
         $unexpectedDefinedPropertyNames = array_diff($this->getDefinedPropertyNames(), $propertyNames);
 
         if (!empty($unexpectedDefinedPropertyNames)) {
@@ -598,7 +609,7 @@ abstract class DataTransferObject
         $this->assertKnownPropertyNames($propertyNames);
 
         $defined = array_filter(
-            (array)$propertyNames,
+            (array) $propertyNames,
             function (string $propertyName) {
                 return $this->isDefined($propertyName);
             }
@@ -616,7 +627,7 @@ abstract class DataTransferObject
      */
     private function assertKnownPropertyNames($propertyNames): void
     {
-        $unknown = array_diff((array)$propertyNames, array_keys($this->propertyTypes));
+        $unknown = array_diff((array) $propertyNames, array_keys($this->propertyTypes));
 
         if (!empty($unknown)) {
             throw new UnknownPropertiesTypeError(static::class, $unknown);

--- a/tests/Unit/CallableTest.php
+++ b/tests/Unit/CallableTest.php
@@ -6,7 +6,6 @@ use Closure;
 use Rexlabs\DataTransferObject\Tests\Support\ExampleDataTransferObject;
 use Rexlabs\DataTransferObject\Tests\TestCase;
 
-use Rexlabs\DataTransferObject\Type\PropertyReference;
 use const Rexlabs\DataTransferObject\PARTIAL;
 
 class CallableTest extends TestCase

--- a/tests/Unit/CallableTest.php
+++ b/tests/Unit/CallableTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Rexlabs\DataTransferObject\Tests\Unit;
+
+use Closure;
+use Rexlabs\DataTransferObject\Tests\Support\ExampleDataTransferObject;
+use Rexlabs\DataTransferObject\Tests\TestCase;
+
+use Rexlabs\DataTransferObject\Type\PropertyReference;
+use const Rexlabs\DataTransferObject\PARTIAL;
+
+class CallableTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public static function can_make_from_closure(): void
+    {
+        $dto = ExampleDataTransferObject::make(function ($ref) {
+            return [
+                $ref->first_name => 'John',
+                $ref->last_name => 'Smith',
+            ];
+        }, PARTIAL);
+
+        self::assertEquals('John', $dto->first_name);
+        self::assertEquals('Smith', $dto->last_name);
+    }
+
+    // /**
+    //  * @test
+    //  * @requires PHP 8.1
+    //  */
+    // public function can_make_from_shorthand_closure(): void
+    // {
+    //     $dto = ExampleDataTransferObject::make(fn($ref) => [
+    //         $ref->first_name => 'Future',
+    //         $ref->last_name => 'Man',
+    //     ], PARTIAL);
+
+    //     self::assertEquals('Future', $dto->first_name);
+    //     self::assertEquals('Man', $dto->last_name);
+    // }
+
+    /**
+     * @test
+     */
+    public function can_make_from_callable(): void
+    {
+        $callable = Closure::fromCallable([$this, 'myTestCallable']);
+        $dto = ExampleDataTransferObject::make($callable, PARTIAL);
+
+        self::assertEquals('Bob', $dto->first_name);
+        self::assertEquals('Roberts', $dto->last_name);
+    }
+
+    private function myTestCallable($ref): array
+    {
+        return [
+            $ref->first_name => 'Bob',
+            $ref->last_name => 'Roberts',
+        ];
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Instead of doing:
```php
$ref = DtoClass:ref();
$dto = DtoClass::make([
    $ref->prop1 => 'my value'
]);
```

You can now optionally do:
```php
$dto = DtoClass::make(fn ($ref) => [
    $ref->prop1 => 'my value'
]);
```

Loom: https://www.loom.com/share/b25fd97f2a534e14b52e05d93c623e58?sid=4284d286-9909-4f45-80ae-81edd1b8181c

## Motivation and context

Developers will often need to have multiple $ref variables with different names when they have complex DTOs and nested DTOs in particular. This becomes confusing and annoying.

## How has this been tested?

New unit tests have been created as part of this PR. Note that one of the tests uses syntax from newer php versions and has been commented out to avoid any issues, though it has been tested and does pass.

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/1c33c562-ac1a-44ce-816e-3afceb062258)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

